### PR TITLE
Extended React motion Menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,16 @@ The `margin` between items or menu button.
 
 If set `true`, menu opened both side, when `vertical` or `horizontal` type selected.
 
+#### `bumpy: PropTypes.bool`
+
+This prop controls if the menu items should open in bumpy mode or in smooth mode.
+Default mode is set to bumpy effect. 
+
+#### `openSpeed: PropTypes.number`
+This prop controls how fast the menu items should open. Default speed is set to 60 milliseconds.
+ 
+#### `reverse: PropTypes.bool`
+This controls if the menu should open in reverse direction.
 
 ## Test
 

--- a/README.md
+++ b/README.md
@@ -80,10 +80,12 @@ This prop controls if the menu items should open in bumpy mode or in smooth mode
 Default mode is set to bumpy effect. 
 
 #### `openSpeed: PropTypes.number`
+
 This prop controls how fast the menu items should open. Default speed is set to 60 milliseconds.
  
 #### `reverse: PropTypes.bool`
-This controls if the menu should open in reverse direction.
+
+This prop controls if the menu should open in reverse direction or not. 
 
 ## Test
 

--- a/docs/dist/bundle.js
+++ b/docs/dist/bundle.js
@@ -19,14 +19,10 @@ exports.default = function () {
   return _react2.default.createElement(
     _src2.default,
     {
-      type: 'horizontal',
+      type: 'circle',
       margin: 120,
       y: 0,
-      bumpy: false,
-      x: 0,
-      openSpeed: 10,
-      wing: false,
-      reverse: true
+      x: 0
     },
     _react2.default.createElement(
       'div',
@@ -293,7 +289,7 @@ module.exports = camelizeStyleName;
  * LICENSE file in the root directory of this source tree. An additional grant
  * of patent rights can be found in the PATENTS file in the same directory.
  *
- * 
+ *
  */
 
 var isTextNode = require('./isTextNode');
@@ -1199,15 +1195,8 @@ if (process.env.NODE_ENV !== 'production') {
 module.exports = warning;
 }).call(this,require('_process'))
 },{"./emptyFunction":10,"_process":28}],26:[function(require,module,exports){
-/*
-object-assign
-(c) Sindre Sorhus
-@license MIT
-*/
-
 'use strict';
 /* eslint-disable no-unused-vars */
-var getOwnPropertySymbols = Object.getOwnPropertySymbols;
 var hasOwnProperty = Object.prototype.hasOwnProperty;
 var propIsEnumerable = Object.prototype.propertyIsEnumerable;
 
@@ -1228,7 +1217,7 @@ function shouldUseNative() {
 		// Detect buggy property enumeration order in older V8 versions.
 
 		// https://bugs.chromium.org/p/v8/issues/detail?id=4118
-		var test1 = new String('abc');  // eslint-disable-line no-new-wrappers
+		var test1 = new String('abc');  // eslint-disable-line
 		test1[5] = 'de';
 		if (Object.getOwnPropertyNames(test1)[0] === '5') {
 			return false;
@@ -1257,7 +1246,7 @@ function shouldUseNative() {
 		}
 
 		return true;
-	} catch (err) {
+	} catch (e) {
 		// We don't expect any of the above to throw, but better to be safe.
 		return false;
 	}
@@ -1277,8 +1266,8 @@ module.exports = shouldUseNative() ? Object.assign : function (target, source) {
 			}
 		}
 
-		if (getOwnPropertySymbols) {
-			symbols = getOwnPropertySymbols(from);
+		if (Object.getOwnPropertySymbols) {
+			symbols = Object.getOwnPropertySymbols(from);
 			for (var i = 0; i < symbols.length; i++) {
 				if (propIsEnumerable.call(from, symbols[i])) {
 					to[symbols[i]] = from[symbols[i]];
@@ -5339,6 +5328,17 @@ var fourArgumentPooler = function (a1, a2, a3, a4) {
   }
 };
 
+var fiveArgumentPooler = function (a1, a2, a3, a4, a5) {
+  var Klass = this;
+  if (Klass.instancePool.length) {
+    var instance = Klass.instancePool.pop();
+    Klass.call(instance, a1, a2, a3, a4, a5);
+    return instance;
+  } else {
+    return new Klass(a1, a2, a3, a4, a5);
+  }
+};
+
 var standardReleaser = function (instance) {
   var Klass = this;
   !(instance instanceof Klass) ? process.env.NODE_ENV !== 'production' ? invariant(false, 'Trying to release an instance into a pool of a different type.') : _prodInvariant('25') : void 0;
@@ -5378,7 +5378,8 @@ var PooledClass = {
   oneArgumentPooler: oneArgumentPooler,
   twoArgumentPooler: twoArgumentPooler,
   threeArgumentPooler: threeArgumentPooler,
-  fourArgumentPooler: fourArgumentPooler
+  fourArgumentPooler: fourArgumentPooler,
+  fiveArgumentPooler: fiveArgumentPooler
 };
 
 module.exports = PooledClass;
@@ -6181,7 +6182,7 @@ var ReactCompositeComponent = {
       // Since plain JS classes are defined without any special initialization
       // logic, we can not catch common errors early. Therefore, we have to
       // catch them here, at initialization time, instead.
-      process.env.NODE_ENV !== 'production' ? warning(!inst.getInitialState || inst.getInitialState.isReactClassApproved || inst.state, 'getInitialState was defined on %s, a plain JavaScript class. ' + 'This is only supported for classes created using React.createClass. ' + 'Did you mean to define a state property instead?', this.getName() || 'a component') : void 0;
+      process.env.NODE_ENV !== 'production' ? warning(!inst.getInitialState || inst.getInitialState.isReactClassApproved, 'getInitialState was defined on %s, a plain JavaScript class. ' + 'This is only supported for classes created using React.createClass. ' + 'Did you mean to define a state property instead?', this.getName() || 'a component') : void 0;
       process.env.NODE_ENV !== 'production' ? warning(!inst.getDefaultProps || inst.getDefaultProps.isReactClassApproved, 'getDefaultProps was defined on %s, a plain JavaScript class. ' + 'This is only supported for classes created using React.createClass. ' + 'Use a static property to define defaultProps instead.', this.getName() || 'a component') : void 0;
       process.env.NODE_ENV !== 'production' ? warning(!inst.propTypes, 'propTypes was defined as an instance property on %s. Use a static ' + 'property to define propTypes instead.', this.getName() || 'a component') : void 0;
       process.env.NODE_ENV !== 'production' ? warning(!inst.contextTypes, 'contextTypes was defined as an instance property on %s. Use a ' + 'static property to define contextTypes instead.', this.getName() || 'a component') : void 0;
@@ -7647,18 +7648,12 @@ ReactDOMComponent.Mixin = {
     } else {
       var contentToUse = CONTENT_TYPES[typeof props.children] ? props.children : null;
       var childrenToUse = contentToUse != null ? null : props.children;
-      // TODO: Validate that text is allowed as a child of this node
       if (contentToUse != null) {
-        // Avoid setting textContent when the text is empty. In IE11 setting
-        // textContent on a text area will cause the placeholder to not
-        // show within the textarea until it has been focused and blurred again.
-        // https://github.com/facebook/react/issues/6731#issuecomment-254874553
-        if (contentToUse !== '') {
-          if (process.env.NODE_ENV !== 'production') {
-            setAndValidateContentChildDev.call(this, contentToUse);
-          }
-          DOMLazyTree.queueText(lazyTree, contentToUse);
+        // TODO: Validate that text is allowed as a child of this node
+        if (process.env.NODE_ENV !== 'production') {
+          setAndValidateContentChildDev.call(this, contentToUse);
         }
+        DOMLazyTree.queueText(lazyTree, contentToUse);
       } else if (childrenToUse != null) {
         var mountImages = this.mountChildren(childrenToUse, transaction, context);
         for (var i = 0; i < mountImages.length; i++) {
@@ -8010,13 +8005,6 @@ var Flags = ReactDOMComponentFlags;
 var internalInstanceKey = '__reactInternalInstance$' + Math.random().toString(36).slice(2);
 
 /**
- * Check if a given node should be cached.
- */
-function shouldPrecacheNode(node, nodeID) {
-  return node.nodeType === 1 && node.getAttribute(ATTR_NAME) === String(nodeID) || node.nodeType === 8 && node.nodeValue === ' react-text: ' + nodeID + ' ' || node.nodeType === 8 && node.nodeValue === ' react-empty: ' + nodeID + ' ';
-}
-
-/**
  * Drill down (through composites and empty components) until we get a host or
  * host text component.
  *
@@ -8081,7 +8069,7 @@ function precacheChildNodes(inst, node) {
     }
     // We assume the child nodes are in the same order as the child instances.
     for (; childNode !== null; childNode = childNode.nextSibling) {
-      if (shouldPrecacheNode(childNode, childID)) {
+      if (childNode.nodeType === 1 && childNode.getAttribute(ATTR_NAME) === String(childID) || childNode.nodeType === 8 && childNode.nodeValue === ' react-text: ' + childID + ' ' || childNode.nodeType === 8 && childNode.nodeValue === ' react-empty: ' + childID + ' ') {
         precacheNode(childInst, childNode);
         continue outer;
       }
@@ -8489,17 +8477,7 @@ var ReactDOMInput = {
       }
     } else {
       if (props.value == null && props.defaultValue != null) {
-        // In Chrome, assigning defaultValue to certain input types triggers input validation.
-        // For number inputs, the display value loses trailing decimal points. For email inputs,
-        // Chrome raises "The specified value <x> is not a valid email address".
-        //
-        // Here we check to see if the defaultValue has actually changed, avoiding these problems
-        // when the user is inputting text
-        //
-        // https://github.com/facebook/react/issues/7253
-        if (node.defaultValue !== '' + props.defaultValue) {
-          node.defaultValue = '' + props.defaultValue;
-        }
+        node.defaultValue = '' + props.defaultValue;
       }
       if (props.checked == null && props.defaultChecked != null) {
         node.defaultChecked = !!props.defaultChecked;
@@ -9594,15 +9572,9 @@ var ReactDOMTextarea = {
     // This is in postMount because we need access to the DOM node, which is not
     // available until after the component has mounted.
     var node = ReactDOMComponentTree.getNodeFromInstance(inst);
-    var textContent = node.textContent;
 
-    // Only set node.value if textContent is equal to the expected
-    // initial value. In IE10/IE11 there is a bug where the placeholder attribute
-    // will populate textContent as well.
-    // https://developer.microsoft.com/microsoft-edge/platform/issues/101525/
-    if (textContent === inst._wrapperState.initialValue) {
-      node.value = textContent;
-    }
+    // Warning: node.value may be the empty string at this point (IE11) if placeholder is set.
+    node.value = node.textContent; // Detach value from defaultValue
   }
 };
 
@@ -10737,11 +10709,14 @@ module.exports = ReactFeatureFlags;
 
 'use strict';
 
-var _prodInvariant = require('./reactProdInvariant');
+var _prodInvariant = require('./reactProdInvariant'),
+    _assign = require('object-assign');
 
 var invariant = require('fbjs/lib/invariant');
 
 var genericComponentClass = null;
+// This registry keeps track of wrapper classes around host tags.
+var tagToComponentClass = {};
 var textComponentClass = null;
 
 var ReactHostComponentInjection = {
@@ -10754,6 +10729,11 @@ var ReactHostComponentInjection = {
   // rendered as props.
   injectTextComponentClass: function (componentClass) {
     textComponentClass = componentClass;
+  },
+  // This accepts a keyed object with classes as values. Each key represents a
+  // tag. That particular tag will use this class instead of the generic one.
+  injectComponentClasses: function (componentClasses) {
+    _assign(tagToComponentClass, componentClasses);
   }
 };
 
@@ -10793,7 +10773,7 @@ var ReactHostComponent = {
 
 module.exports = ReactHostComponent;
 }).call(this,require('_process'))
-},{"./reactProdInvariant":150,"_process":28,"fbjs/lib/invariant":18}],88:[function(require,module,exports){
+},{"./reactProdInvariant":150,"_process":28,"fbjs/lib/invariant":18,"object-assign":26}],88:[function(require,module,exports){
 /**
  * Copyright 2016-present, Facebook, Inc.
  * All rights reserved.
@@ -13488,7 +13468,7 @@ module.exports = ReactUpdates;
 
 'use strict';
 
-module.exports = '15.4.2';
+module.exports = '15.4.1';
 },{}],109:[function(require,module,exports){
 /**
  * Copyright 2013-present, Facebook, Inc.
@@ -16510,17 +16490,7 @@ function instantiateReactComponent(node, shouldHaveDebugID) {
     instance = ReactEmptyComponent.create(instantiateReactComponent);
   } else if (typeof node === 'object') {
     var element = node;
-    var type = element.type;
-    if (typeof type !== 'function' && typeof type !== 'string') {
-      var info = '';
-      if (process.env.NODE_ENV !== 'production') {
-        if (type === undefined || typeof type === 'object' && type !== null && Object.keys(type).length === 0) {
-          info += ' You likely forgot to export your component from the file ' + 'it\'s defined in.';
-        }
-      }
-      info += getDeclarationErrorAddendum(element._owner);
-      !false ? process.env.NODE_ENV !== 'production' ? invariant(false, 'Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: %s.%s', type == null ? type : typeof type, info) : _prodInvariant('130', type == null ? type : typeof type, info) : void 0;
-    }
+    !(element && (typeof element.type === 'function' || typeof element.type === 'string')) ? process.env.NODE_ENV !== 'production' ? invariant(false, 'Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: %s.%s', element.type == null ? element.type : typeof element.type, getDeclarationErrorAddendum(element._owner)) : _prodInvariant('130', element.type == null ? element.type : typeof element.type, getDeclarationErrorAddendum(element._owner)) : void 0;
 
     // Special case string values
     if (typeof element.type === 'string') {
@@ -20998,14 +20968,7 @@ var ReactElementValidator = {
     // We warn in this case but don't throw. We expect the element creation to
     // succeed and there will likely be errors in render.
     if (!validType) {
-      if (typeof type !== 'function' && typeof type !== 'string') {
-        var info = '';
-        if (type === undefined || typeof type === 'object' && type !== null && Object.keys(type).length === 0) {
-          info += ' You likely forgot to export your component from the file ' + 'it\'s defined in.';
-        }
-        info += getDeclarationErrorAddendum();
-        process.env.NODE_ENV !== 'production' ? warning(false, 'React.createElement: type is invalid -- expected a string (for ' + 'built-in components) or a class/function (for composite ' + 'components) but got: %s.%s', type == null ? type : typeof type, info) : void 0;
-      }
+      process.env.NODE_ENV !== 'production' ? warning(false, 'React.createElement: type should not be null, undefined, boolean, or ' + 'number. It should be a string (for DOM elements) or a ReactClass ' + '(for composite components).%s', getDeclarationErrorAddendum()) : void 0;
     }
 
     var element = ReactElement.createElement.apply(this, arguments);
@@ -22030,21 +21993,12 @@ var MenuButton = function (_Component) {
     _this.state = {
       sequence: 0
     };
-    _this.sequenceParams = _this.props.bumpy ? [{
+    _this.sequenceParams = [{
       scaleX: (0, _reactMotion.spring)(1, { stiffness: 1500, damping: 10 }),
       scaleY: (0, _reactMotion.spring)(1, { stiffness: 1500, damping: 10 })
     }, {
       scaleX: (0, _reactMotion.spring)(0.6, { stiffness: 1500, damping: 50 }),
       scaleY: (0, _reactMotion.spring)(0.6, { stiffness: 1500, damping: 50 })
-    }, {
-      scaleX: (0, _reactMotion.spring)(1, { stiffness: 1500, damping: 10 }),
-      scaleY: (0, _reactMotion.spring)(1, { stiffness: 1500, damping: 10 })
-    }] : [{
-      scaleX: (0, _reactMotion.spring)(1, { stiffness: 1500, damping: 10 }),
-      scaleY: (0, _reactMotion.spring)(1, { stiffness: 1500, damping: 10 })
-    }, {
-      scaleX: (0, _reactMotion.spring)(1, { stiffness: 200, damping: 50 }),
-      scaleY: (0, _reactMotion.spring)(1, { stiffness: 200, damping: 50 })
     }, {
       scaleX: (0, _reactMotion.spring)(1, { stiffness: 1500, damping: 10 }),
       scaleY: (0, _reactMotion.spring)(1, { stiffness: 1500, damping: 10 })
@@ -22093,7 +22047,7 @@ var MenuButton = function (_Component) {
               scaleY = _ref.scaleY;
           return (0, _react.cloneElement)(_this4.props.children, _extends({}, _this4.props.children.props || {}, {
             onClick: onClick,
-            style: _extends({}, _this4.props.children.props && _this4.props.children.props.style || {}, {
+            style: _extends({}, _this4.props.children.props.style, {
               transform: 'translate3d(' + x + 'px, ' + y + 'px, 0) scaleX(' + scaleX + ') scaleY(' + scaleY + ')',
               WebkitTransform: 'translate3d(' + x + 'px, ' + y + 'px, 0) scaleX(' + scaleX + ') scaleY(' + scaleY + ')',
               position: 'absolute'
@@ -22110,8 +22064,7 @@ var MenuButton = function (_Component) {
 MenuButton.propTypes = {
   x: _react.PropTypes.number.isRequired,
   y: _react.PropTypes.number.isRequired,
-  onClick: _react.PropTypes.func,
-  bumpy: _react.PropTypes.bool
+  onClick: _react.PropTypes.func
 };
 exports.default = MenuButton;
 
@@ -22244,13 +22197,13 @@ var MotionMenu = function (_Component) {
 
       var _props3 = this.props,
           x = _props3.x,
-          y = _props3.y,
-          bumpy = _props3.bumpy;
+          y = _props3.y;
 
       return Array.from(Array(this.state.itemNumber).keys()).reverse().map(function (i) {
         return _react2.default.createElement(
           _item2.default,
           {
+            direction: _this2.props.type,
             key: i,
             ref: function ref(c) {
               _this2.items[i + 1] = c;
@@ -22259,11 +22212,7 @@ var MotionMenu = function (_Component) {
             onOpenAnimationEnd: _this2.onOpenEnd,
             onCloseAnimationEnd: _this2.onCloseEnd,
             x: _this2.getX(i, x),
-            y: _this2.getY(i, y),
-            bumpy: bumpy,
-            openSpeed: _this2.props.openSpeed,
-            reverse: _this2.props.reverse,
-            type: _this2.props.type
+            y: _this2.getY(i, y)
           },
           _this2.props.children[i + 1]
         );
@@ -22329,8 +22278,7 @@ var MotionMenu = function (_Component) {
           },
           onClick: this.onClick,
           x: this.props.x,
-          y: this.props.y,
-          bumpy: this.props.bumpy
+          y: this.props.y
         },
         this.props.children[0]
       );
@@ -22348,20 +22296,14 @@ MotionMenu.propTypes = {
   y: _react.PropTypes.number,
   onClose: _react.PropTypes.func,
   onOpen: _react.PropTypes.func,
-  className: _react.PropTypes.string,
-  bumpy: _react.PropTypes.bool,
-  openSpeed: _react.PropTypes.number,
-  reverse: _react.PropTypes.bool
+  className: _react.PropTypes.string
 };
 MotionMenu.defaultProps = {
   x: 0,
   y: 0,
   style: {},
   onClose: function onClose() {},
-  onOpen: function onOpen() {},
-  bumpy: false,
-  openSpeed: 60,
-  reverse: false
+  onOpen: function onOpen() {}
 };
 exports.default = MotionMenu;
 
@@ -22390,28 +22332,9 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var createSmoothParams = function createSmoothParams(_ref) {
+var createParams = function createParams(_ref) {
   var x = _ref.x,
       y = _ref.y;
-  return [{
-    scaleX: (0, _reactMotion.spring)(0, { stiffness: 1500, damping: 100 }),
-    scaleY: (0, _reactMotion.spring)(0, { stiffness: 1500, damping: 100 }),
-    x: (0, _reactMotion.spring)(x, { stiffness: 1500, damping: 50 }),
-    y: (0, _reactMotion.spring)(y, { stiffness: 1500, damping: 50 })
-  }, {
-    scaleX: (0, _reactMotion.spring)(0.5, { stiffness: 120, damping: 20 }),
-    scaleY: (0, _reactMotion.spring)(0.5, { stiffness: 120, damping: 20 }),
-    x: (0, _reactMotion.spring)(x, { stiffness: 120, damping: 20 }),
-    y: (0, _reactMotion.spring)(y, { stiffness: 120, damping: 20 })
-  }, {
-    scaleX: (0, _reactMotion.spring)(1, { stiffness: 120, damping: 20 }),
-    scaleY: (0, _reactMotion.spring)(1, { stiffness: 120, damping: 20 }),
-    x: (0, _reactMotion.spring)(x, { stiffness: 120, damping: 20 }),
-    y: (0, _reactMotion.spring)(y, { stiffness: 120, damping: 20 })
-  }];
-};
-
-var createBumpyParams = function createBumpyParams(x, y) {
   return [{
     scaleX: (0, _reactMotion.spring)(0, { stiffness: 1500, damping: 100 }),
     scaleY: (0, _reactMotion.spring)(0, { stiffness: 1500, damping: 100 }),
@@ -22442,8 +22365,7 @@ var MenuItem = function (_Component) {
     _this.state = {
       sequence: 0
     };
-
-    _this.sequenceParams = _this.props.bumpy ? createBumpyParams(props) : createSmoothParams(props);
+    _this.sequenceParams = createParams(props);
     return _this;
   }
 
@@ -22455,13 +22377,13 @@ var MenuItem = function (_Component) {
       this.timerIds[1] = setTimeout(function () {
         _this2.setState({ sequence: 1 });
         _this2.timerIds[1] = null;
-      }, this.props.openSpeed);
+      }, 60);
 
       this.timerIds[2] = setTimeout(function () {
         _this2.setState({ sequence: 2 });
         _this2.timerIds[2] = null;
         _this2.props.onOpenAnimationEnd(_this2.props.name);
-      }, this.props.openSpeed);
+      }, 80);
     }
   }, {
     key: 'reverse',
@@ -22474,7 +22396,7 @@ var MenuItem = function (_Component) {
       this.timerIds[0] = setTimeout(function () {
         _this3.timerIds[0] = null;
         _this3.props.onCloseAnimationEnd(_this3.props.name);
-      }, 80);
+      }, 100);
       this.setState({ sequence: 0 });
     }
   }, {
@@ -22484,12 +22406,8 @@ var MenuItem = function (_Component) {
 
       var _props = this.props,
           x = _props.x,
-          y = _props.y,
-          reverse = _props.reverse,
-          type = _props.type;
+          y = _props.y;
 
-      var _x = reverse ? -1 * x : x;
-      var _y = type === 'vertical' && reverse ? -1 * y : y;
       if (!this.props.children) return null;
       return _react2.default.createElement(
         _reactMotion.Motion,
@@ -22498,9 +22416,9 @@ var MenuItem = function (_Component) {
           var scaleX = _ref2.scaleX,
               scaleY = _ref2.scaleY;
           return (0, _react.cloneElement)(_this4.props.children, _extends({}, _this4.props.children.props || {}, {
-            style: _extends({}, _this4.props.children.props && _this4.props.children.props.style || {}, {
-              transform: 'translate3d(' + _x + 'px, ' + _y + 'px, 0) scaleX(' + scaleX + ') scaleY(' + scaleY + ')',
-              WebkitTransform: 'translate3d(' + _x + 'px, ' + _y + 'px, 0) scaleX(' + scaleX + ') scaleY(' + scaleY + ')',
+            style: _extends({}, _this4.props.children.props.style, {
+              transform: 'translate3d(' + x + 'px, ' + y + 'px, 0) scaleX(' + scaleX + ') scaleY(' + scaleY + ')',
+              WebkitTransform: 'translate3d(' + x + 'px, ' + y + 'px, 0) scaleX(' + scaleX + ') scaleY(' + scaleY + ')',
               position: 'absolute'
             })
           }));
@@ -22517,12 +22435,7 @@ MenuItem.propTypes = {
   y: _react.PropTypes.number.isRequired,
   name: _react.PropTypes.string.isRequired,
   onOpenAnimationEnd: _react.PropTypes.func,
-  onCloseAnimationEnd: _react.PropTypes.func,
-  bumpy: _react.PropTypes.bool.isRequired,
-  speedOpen: _react.PropTypes.number,
-  openSpeed: _react.PropTypes.number,
-  reverse: _react.PropTypes.bool,
-  type: _react.PropTypes.oneOf(['horizontal', 'vertical', 'circle']).isRequired
+  onCloseAnimationEnd: _react.PropTypes.func
 };
 MenuItem.defaultProps = {
   onOpenAnimationEnd: function onOpenAnimationEnd() {},

--- a/docs/dist/bundle.js
+++ b/docs/dist/bundle.js
@@ -2,7 +2,7 @@
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
-    value: true
+  value: true
 });
 
 var _react = require('react');
@@ -16,59 +16,59 @@ var _src2 = _interopRequireDefault(_src);
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 exports.default = function () {
-    return _react2.default.createElement(
-        _src2.default,
-        {
-            type: 'vertical',
-            margin: 120,
-            y: 0,
-            bumpy: false,
-            x: 0,
-            openSpeed: 60,
-            wing: true,
-            reverse: true
-        },
-        _react2.default.createElement(
-            'div',
-            { className: 'button' },
-            _react2.default.createElement('i', { className: 'fa fa-bars' })
-        ),
-        _react2.default.createElement(
-            'div',
-            { className: 'button' },
-            _react2.default.createElement('i', { className: 'fa fa-cogs' })
-        ),
-        _react2.default.createElement(
-            'div',
-            { className: 'button' },
-            _react2.default.createElement('i', { className: 'fa fa-cloud' })
-        ),
-        _react2.default.createElement(
-            'div',
-            { className: 'button' },
-            _react2.default.createElement('i', { className: 'fa fa-home' })
-        ),
-        _react2.default.createElement(
-            'div',
-            { className: 'button' },
-            _react2.default.createElement('i', { className: 'fa fa-flash' })
-        ),
-        _react2.default.createElement(
-            'div',
-            { className: 'button' },
-            _react2.default.createElement('i', { className: 'fa fa-heart' })
-        ),
-        _react2.default.createElement(
-            'div',
-            { className: 'button' },
-            _react2.default.createElement('i', { className: 'fa fa-globe' })
-        ),
-        _react2.default.createElement(
-            'div',
-            { className: 'button' },
-            _react2.default.createElement('i', { className: 'fa fa-plug' })
-        )
-    );
+  return _react2.default.createElement(
+    _src2.default,
+    {
+      type: 'horizontal',
+      margin: 120,
+      y: 0,
+      bumpy: false,
+      x: 0,
+      openSpeed: 10,
+      wing: false,
+      reverse: true
+    },
+    _react2.default.createElement(
+      'div',
+      { className: 'button' },
+      _react2.default.createElement('i', { className: 'fa fa-bars' })
+    ),
+    _react2.default.createElement(
+      'div',
+      { className: 'button' },
+      _react2.default.createElement('i', { className: 'fa fa-cogs' })
+    ),
+    _react2.default.createElement(
+      'div',
+      { className: 'button' },
+      _react2.default.createElement('i', { className: 'fa fa-cloud' })
+    ),
+    _react2.default.createElement(
+      'div',
+      { className: 'button' },
+      _react2.default.createElement('i', { className: 'fa fa-home' })
+    ),
+    _react2.default.createElement(
+      'div',
+      { className: 'button' },
+      _react2.default.createElement('i', { className: 'fa fa-flash' })
+    ),
+    _react2.default.createElement(
+      'div',
+      { className: 'button' },
+      _react2.default.createElement('i', { className: 'fa fa-heart' })
+    ),
+    _react2.default.createElement(
+      'div',
+      { className: 'button' },
+      _react2.default.createElement('i', { className: 'fa fa-globe' })
+    ),
+    _react2.default.createElement(
+      'div',
+      { className: 'button' },
+      _react2.default.createElement('i', { className: 'fa fa-plug' })
+    )
+  );
 };
 
 },{"../../src":195,"react":193}],2:[function(require,module,exports){
@@ -22119,7 +22119,7 @@ exports.default = MenuButton;
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
-    value: true
+  value: true
 });
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -22145,223 +22145,223 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var MotionMenu = function (_Component) {
-    _inherits(MotionMenu, _Component);
+  _inherits(MotionMenu, _Component);
 
-    function MotionMenu(props) {
-        _classCallCheck(this, MotionMenu);
+  function MotionMenu(props) {
+    _classCallCheck(this, MotionMenu);
 
-        var _this = _possibleConstructorReturn(this, (MotionMenu.__proto__ || Object.getPrototypeOf(MotionMenu)).call(this, props));
+    var _this = _possibleConstructorReturn(this, (MotionMenu.__proto__ || Object.getPrototypeOf(MotionMenu)).call(this, props));
 
-        _this.state = {
-            itemNumber: 1,
-            status: 'idle'
-        };
-        _this.items = [];
-        _this.onOpenEnd = _this.onOpenEnd.bind(_this);
-        _this.onCloseEnd = _this.onCloseEnd.bind(_this);
-        _this.onClick = _this.onClick.bind(_this);
-        return _this;
+    _this.state = {
+      itemNumber: 1,
+      status: 'idle'
+    };
+    _this.items = [];
+    _this.onOpenEnd = _this.onOpenEnd.bind(_this);
+    _this.onCloseEnd = _this.onCloseEnd.bind(_this);
+    _this.onClick = _this.onClick.bind(_this);
+    return _this;
+  }
+
+  _createClass(MotionMenu, [{
+    key: 'onOpenEnd',
+    value: function onOpenEnd(name) {
+      if (this.state.action !== 'open') return;
+      if (this.state.itemNumber < this.props.children.length) {
+        this.items[this.state.itemNumber].start();
+        this.setState({
+          itemNumber: this.state.itemNumber + 1
+        });
+        return;
+      }
+      if (name === 'item' + (this.props.children.length - 1)) {
+        this.props.onOpen();
+      }
     }
+  }, {
+    key: 'onCloseEnd',
+    value: function onCloseEnd(name) {
+      if (this.state.action === 'open') return;
+      if (this.state.itemNumber > 1) {
+        if (name === 'item1') {
+          this.props.onClose();
+        }
+        this.setState({
+          itemNumber: this.state.itemNumber - 1
+        });
+      }
+    }
+  }, {
+    key: 'onClick',
+    value: function onClick() {
+      if (this.state.action === 'open') {
+        this.closeItems();
+      } else {
+        this.openItem();
+      }
+    }
+  }, {
+    key: 'getDistance',
+    value: function getDistance(i) {
+      return this.props.wing ? (parseInt(i / 2, 10) + 1) * this.props.margin * (i % 2 || -1) : this.props.margin * (i + 1);
+    }
+  }, {
+    key: 'getX',
+    value: function getX(i, x) {
+      var _props = this.props,
+          type = _props.type,
+          margin = _props.margin,
+          children = _props.children;
 
-    _createClass(MotionMenu, [{
-        key: 'onOpenEnd',
-        value: function onOpenEnd(name) {
-            if (this.state.action !== 'open') return;
-            if (this.state.itemNumber < this.props.children.length) {
-                this.items[this.state.itemNumber].start();
-                this.setState({
-                    itemNumber: this.state.itemNumber + 1
-                });
-                return;
-            }
-            if (name === 'item' + (this.props.children.length - 1)) {
-                this.props.onOpen();
-            }
-        }
-    }, {
-        key: 'onCloseEnd',
-        value: function onCloseEnd(name) {
-            if (this.state.action === 'open') return;
-            if (this.state.itemNumber > 1) {
-                if (name === 'item1') {
-                    this.props.onClose();
-                }
-                this.setState({
-                    itemNumber: this.state.itemNumber - 1
-                });
-            }
-        }
-    }, {
-        key: 'onClick',
-        value: function onClick() {
-            if (this.state.action === 'open') {
-                this.closeItems();
-            } else {
-                this.openItem();
-            }
-        }
-    }, {
-        key: 'getDistance',
-        value: function getDistance(i) {
-            return this.props.wing ? (parseInt(i / 2, 10) + 1) * this.props.margin * (i % 2 || -1) : this.props.margin * (i + 1);
-        }
-    }, {
-        key: 'getX',
-        value: function getX(i, x) {
-            var _props = this.props,
-                type = _props.type,
-                margin = _props.margin,
-                children = _props.children;
+      if (type === 'horizontal') {
+        return this.getDistance(i) + x;
+      }
+      if (type === 'circle') {
+        return x + margin * Math.cos(Math.PI * 2 * i / (children.length - 1));
+      }
+      return x;
+    }
+  }, {
+    key: 'getY',
+    value: function getY(i, y) {
+      var _props2 = this.props,
+          type = _props2.type,
+          margin = _props2.margin,
+          children = _props2.children;
 
-            if (type === 'horizontal') {
-                return this.getDistance(i) + x;
-            }
-            if (type === 'circle') {
-                return x + margin * Math.cos(Math.PI * 2 * i / (children.length - 1));
-            }
-            return x;
-        }
-    }, {
-        key: 'getY',
-        value: function getY(i, y) {
-            var _props2 = this.props,
-                type = _props2.type,
-                margin = _props2.margin,
-                children = _props2.children;
+      if (type === 'vertical') {
+        return this.getDistance(i) + y;
+      }
+      if (type === 'circle') {
+        return y + margin * Math.sin(Math.PI * 2 * i / (children.length - 1));
+      }
+      return y;
+    }
+  }, {
+    key: 'getItems',
+    value: function getItems() {
+      var _this2 = this;
 
-            if (type === 'vertical') {
-                return this.getDistance(i) + y;
-            }
-            if (type === 'circle') {
-                return y + margin * Math.sin(Math.PI * 2 * i / (children.length - 1));
-            }
-            return y;
-        }
-    }, {
-        key: 'getItems',
-        value: function getItems() {
-            var _this2 = this;
+      var _props3 = this.props,
+          x = _props3.x,
+          y = _props3.y,
+          bumpy = _props3.bumpy;
 
-            var _props3 = this.props,
-                x = _props3.x,
-                y = _props3.y,
-                bumpy = _props3.bumpy;
+      return Array.from(Array(this.state.itemNumber).keys()).reverse().map(function (i) {
+        return _react2.default.createElement(
+          _item2.default,
+          {
+            key: i,
+            ref: function ref(c) {
+              _this2.items[i + 1] = c;
+            },
+            name: 'item' + (i + 1),
+            onOpenAnimationEnd: _this2.onOpenEnd,
+            onCloseAnimationEnd: _this2.onCloseEnd,
+            x: _this2.getX(i, x),
+            y: _this2.getY(i, y),
+            bumpy: bumpy,
+            openSpeed: _this2.props.openSpeed,
+            reverse: _this2.props.reverse,
+            type: _this2.props.type
+          },
+          _this2.props.children[i + 1]
+        );
+      });
+    }
+  }, {
+    key: 'closeItems',
+    value: function closeItems() {
+      var _this3 = this;
 
-            return Array.from(Array(this.state.itemNumber).keys()).reverse().map(function (i) {
-                return _react2.default.createElement(
-                    _item2.default,
-                    {
-                        key: i,
-                        ref: function ref(c) {
-                            _this2.items[i + 1] = c;
-                        },
-                        name: 'item' + (i + 1),
-                        onOpenAnimationEnd: _this2.onOpenEnd,
-                        onCloseAnimationEnd: _this2.onCloseEnd,
-                        x: _this2.getX(i, x),
-                        y: _this2.getY(i, y),
-                        bumpy: bumpy,
-                        openSpeed: _this2.props.openSpeed,
-                        reverse: _this2.props.reverse,
-                        type: _this2.props.type
-                    },
-                    _this2.props.children[i + 1]
-                );
-            });
-        }
-    }, {
-        key: 'closeItems',
-        value: function closeItems() {
-            var _this3 = this;
+      this.setState({ action: 'close' });
+      this.button.reverse();
+      Array.from(Array(this.state.itemNumber).keys()).reverse().forEach(function (i) {
+        return _this3.items[i + 1].reverse();
+      });
+    }
+  }, {
+    key: 'close',
+    value: function close() {
+      if (this.state.action !== 'open') return;
+      this.closeItems();
+    }
+  }, {
+    key: 'open',
+    value: function open() {
+      if (this.state.action === 'open') return;
+      this.openItem();
+    }
+  }, {
+    key: 'openItem',
+    value: function openItem() {
+      this.setState({ action: 'open' });
+      this.button.start();
+      this.items[this.state.itemNumber].start();
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      return _react2.default.createElement(
+        'div',
+        {
+          style: this.props.style,
+          className: this.props.className
+        },
+        _react2.default.createElement(
+          'div',
+          { style: { position: 'relative' } },
+          this.menuButton,
+          this.getItems()
+        )
+      );
+    }
+  }, {
+    key: 'menuButton',
+    get: function get() {
+      var _this4 = this;
 
-            this.setState({ action: 'close' });
-            this.button.reverse();
-            Array.from(Array(this.state.itemNumber).keys()).reverse().forEach(function (i) {
-                return _this3.items[i + 1].reverse();
-            });
-        }
-    }, {
-        key: 'close',
-        value: function close() {
-            if (this.state.action !== 'open') return;
-            this.closeItems();
-        }
-    }, {
-        key: 'open',
-        value: function open() {
-            if (this.state.action === 'open') return;
-            this.openItem();
-        }
-    }, {
-        key: 'openItem',
-        value: function openItem() {
-            this.setState({ action: 'open' });
-            this.button.start();
-            this.items[this.state.itemNumber].start();
-        }
-    }, {
-        key: 'render',
-        value: function render() {
-            return _react2.default.createElement(
-                'div',
-                {
-                    style: this.props.style,
-                    className: this.props.className
-                },
-                _react2.default.createElement(
-                    'div',
-                    { style: { position: 'relative' } },
-                    this.menuButton,
-                    this.getItems()
-                )
-            );
-        }
-    }, {
-        key: 'menuButton',
-        get: function get() {
-            var _this4 = this;
+      return _react2.default.createElement(
+        _button2.default,
+        {
+          ref: function ref(c) {
+            _this4.button = c;
+          },
+          onClick: this.onClick,
+          x: this.props.x,
+          y: this.props.y,
+          bumpy: this.props.bumpy
+        },
+        this.props.children[0]
+      );
+    }
+  }]);
 
-            return _react2.default.createElement(
-                _button2.default,
-                {
-                    ref: function ref(c) {
-                        _this4.button = c;
-                    },
-                    onClick: this.onClick,
-                    x: this.props.x,
-                    y: this.props.y,
-                    bumpy: this.props.bumpy
-                },
-                this.props.children[0]
-            );
-        }
-    }]);
-
-    return MotionMenu;
+  return MotionMenu;
 }(_react.Component);
 
 MotionMenu.propTypes = {
-    margin: _react.PropTypes.number.isRequired,
-    type: _react.PropTypes.oneOf(['horizontal', 'vertical', 'circle']).isRequired,
-    wing: _react.PropTypes.bool,
-    x: _react.PropTypes.number,
-    y: _react.PropTypes.number,
-    onClose: _react.PropTypes.func,
-    onOpen: _react.PropTypes.func,
-    className: _react.PropTypes.string,
-    bumpy: _react.PropTypes.bool,
-    openSpeed: _react.PropTypes.number,
-    reverse: _react.PropTypes.bool
+  margin: _react.PropTypes.number.isRequired,
+  type: _react.PropTypes.oneOf(['horizontal', 'vertical', 'circle']).isRequired,
+  wing: _react.PropTypes.bool,
+  x: _react.PropTypes.number,
+  y: _react.PropTypes.number,
+  onClose: _react.PropTypes.func,
+  onOpen: _react.PropTypes.func,
+  className: _react.PropTypes.string,
+  bumpy: _react.PropTypes.bool,
+  openSpeed: _react.PropTypes.number,
+  reverse: _react.PropTypes.bool
 };
 MotionMenu.defaultProps = {
-    x: 0,
-    y: 0,
-    style: {},
-    onClose: function onClose() {},
-    onOpen: function onOpen() {},
-    bumpy: false,
-    openSpeed: 60,
-    reverse: false
+  x: 0,
+  y: 0,
+  style: {},
+  onClose: function onClose() {},
+  onOpen: function onOpen() {},
+  bumpy: false,
+  openSpeed: 60,
+  reverse: false
 };
 exports.default = MotionMenu;
 
@@ -22369,7 +22369,7 @@ exports.default = MotionMenu;
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
-    value: true
+  value: true
 });
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
@@ -22391,142 +22391,142 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var createSmoothParams = function createSmoothParams(_ref) {
-    var x = _ref.x,
-        y = _ref.y;
-    return [{
-        scaleX: (0, _reactMotion.spring)(0, { stiffness: 1500, damping: 100 }),
-        scaleY: (0, _reactMotion.spring)(0, { stiffness: 1500, damping: 100 }),
-        x: (0, _reactMotion.spring)(x, { stiffness: 1500, damping: 50 }),
-        y: (0, _reactMotion.spring)(y, { stiffness: 1500, damping: 50 })
-    }, {
-        scaleX: (0, _reactMotion.spring)(0.5, { stiffness: 120, damping: 20 }),
-        scaleY: (0, _reactMotion.spring)(0.5, { stiffness: 120, damping: 20 }),
-        x: (0, _reactMotion.spring)(x, { stiffness: 120, damping: 20 }),
-        y: (0, _reactMotion.spring)(y, { stiffness: 120, damping: 20 })
-    }, {
-        scaleX: (0, _reactMotion.spring)(1, { stiffness: 120, damping: 20 }),
-        scaleY: (0, _reactMotion.spring)(1, { stiffness: 120, damping: 20 }),
-        x: (0, _reactMotion.spring)(x, { stiffness: 120, damping: 20 }),
-        y: (0, _reactMotion.spring)(y, { stiffness: 120, damping: 20 })
-    }];
+  var x = _ref.x,
+      y = _ref.y;
+  return [{
+    scaleX: (0, _reactMotion.spring)(0, { stiffness: 1500, damping: 100 }),
+    scaleY: (0, _reactMotion.spring)(0, { stiffness: 1500, damping: 100 }),
+    x: (0, _reactMotion.spring)(x, { stiffness: 1500, damping: 50 }),
+    y: (0, _reactMotion.spring)(y, { stiffness: 1500, damping: 50 })
+  }, {
+    scaleX: (0, _reactMotion.spring)(0.5, { stiffness: 120, damping: 20 }),
+    scaleY: (0, _reactMotion.spring)(0.5, { stiffness: 120, damping: 20 }),
+    x: (0, _reactMotion.spring)(x, { stiffness: 120, damping: 20 }),
+    y: (0, _reactMotion.spring)(y, { stiffness: 120, damping: 20 })
+  }, {
+    scaleX: (0, _reactMotion.spring)(1, { stiffness: 120, damping: 20 }),
+    scaleY: (0, _reactMotion.spring)(1, { stiffness: 120, damping: 20 }),
+    x: (0, _reactMotion.spring)(x, { stiffness: 120, damping: 20 }),
+    y: (0, _reactMotion.spring)(y, { stiffness: 120, damping: 20 })
+  }];
 };
 
 var createBumpyParams = function createBumpyParams(x, y) {
-    return [{
-        scaleX: (0, _reactMotion.spring)(0, { stiffness: 1500, damping: 100 }),
-        scaleY: (0, _reactMotion.spring)(0, { stiffness: 1500, damping: 100 }),
-        x: (0, _reactMotion.spring)(x, { stiffness: 1500, damping: 50 }),
-        y: (0, _reactMotion.spring)(y, { stiffness: 1500, damping: 50 })
-    }, {
-        scaleX: (0, _reactMotion.spring)(1.6, { stiffness: 1500, damping: 150 }),
-        scaleY: (0, _reactMotion.spring)(0.7, { stiffness: 1500, damping: 150 }),
-        x: (0, _reactMotion.spring)(x, { stiffness: 1500, damping: 100 }),
-        y: (0, _reactMotion.spring)(y, { stiffness: 1500, damping: 100 })
-    }, {
-        scaleX: (0, _reactMotion.spring)(1, { stiffness: 1500, damping: 18 }),
-        scaleY: (0, _reactMotion.spring)(1, { stiffness: 1500, damping: 18 }),
-        x: (0, _reactMotion.spring)(x, { stiffness: 1500, damping: 100 }),
-        y: (0, _reactMotion.spring)(y, { stiffness: 1500, damping: 100 })
-    }];
+  return [{
+    scaleX: (0, _reactMotion.spring)(0, { stiffness: 1500, damping: 100 }),
+    scaleY: (0, _reactMotion.spring)(0, { stiffness: 1500, damping: 100 }),
+    x: (0, _reactMotion.spring)(x, { stiffness: 1500, damping: 50 }),
+    y: (0, _reactMotion.spring)(y, { stiffness: 1500, damping: 50 })
+  }, {
+    scaleX: (0, _reactMotion.spring)(1.6, { stiffness: 1500, damping: 150 }),
+    scaleY: (0, _reactMotion.spring)(0.7, { stiffness: 1500, damping: 150 }),
+    x: (0, _reactMotion.spring)(x, { stiffness: 1500, damping: 100 }),
+    y: (0, _reactMotion.spring)(y, { stiffness: 1500, damping: 100 })
+  }, {
+    scaleX: (0, _reactMotion.spring)(1, { stiffness: 1500, damping: 18 }),
+    scaleY: (0, _reactMotion.spring)(1, { stiffness: 1500, damping: 18 }),
+    x: (0, _reactMotion.spring)(x, { stiffness: 1500, damping: 100 }),
+    y: (0, _reactMotion.spring)(y, { stiffness: 1500, damping: 100 })
+  }];
 };
 
 var MenuItem = function (_Component) {
-    _inherits(MenuItem, _Component);
+  _inherits(MenuItem, _Component);
 
-    function MenuItem(props) {
-        _classCallCheck(this, MenuItem);
+  function MenuItem(props) {
+    _classCallCheck(this, MenuItem);
 
-        var _this = _possibleConstructorReturn(this, (MenuItem.__proto__ || Object.getPrototypeOf(MenuItem)).call(this, props));
+    var _this = _possibleConstructorReturn(this, (MenuItem.__proto__ || Object.getPrototypeOf(MenuItem)).call(this, props));
 
-        _this.timerIds = [];
-        _this.state = {
-            sequence: 0
-        };
+    _this.timerIds = [];
+    _this.state = {
+      sequence: 0
+    };
 
-        _this.sequenceParams = _this.props.bumpy ? createBumpyParams(props) : createSmoothParams(props);
-        return _this;
+    _this.sequenceParams = _this.props.bumpy ? createBumpyParams(props) : createSmoothParams(props);
+    return _this;
+  }
+
+  _createClass(MenuItem, [{
+    key: 'start',
+    value: function start() {
+      var _this2 = this;
+
+      this.timerIds[1] = setTimeout(function () {
+        _this2.setState({ sequence: 1 });
+        _this2.timerIds[1] = null;
+      }, this.props.openSpeed);
+
+      this.timerIds[2] = setTimeout(function () {
+        _this2.setState({ sequence: 2 });
+        _this2.timerIds[2] = null;
+        _this2.props.onOpenAnimationEnd(_this2.props.name);
+      }, this.props.openSpeed);
     }
+  }, {
+    key: 'reverse',
+    value: function reverse() {
+      var _this3 = this;
 
-    _createClass(MenuItem, [{
-        key: 'start',
-        value: function start() {
-            var _this2 = this;
+      this.timerIds.forEach(function (id) {
+        if (id) clearTimeout(id);
+      });
+      this.timerIds[0] = setTimeout(function () {
+        _this3.timerIds[0] = null;
+        _this3.props.onCloseAnimationEnd(_this3.props.name);
+      }, 80);
+      this.setState({ sequence: 0 });
+    }
+  }, {
+    key: 'render',
+    value: function render() {
+      var _this4 = this;
 
-            this.timerIds[1] = setTimeout(function () {
-                _this2.setState({ sequence: 1 });
-                _this2.timerIds[1] = null;
-            }, this.props.openSpeed);
+      var _props = this.props,
+          x = _props.x,
+          y = _props.y,
+          reverse = _props.reverse,
+          type = _props.type;
 
-            this.timerIds[2] = setTimeout(function () {
-                _this2.setState({ sequence: 2 });
-                _this2.timerIds[2] = null;
-                _this2.props.onOpenAnimationEnd(_this2.props.name);
-            }, this.props.openSpeed);
+      var _x = reverse ? -1 * x : x;
+      var _y = type === 'vertical' && reverse ? -1 * y : y;
+      if (!this.props.children) return null;
+      return _react2.default.createElement(
+        _reactMotion.Motion,
+        { style: this.sequenceParams[this.state.sequence] },
+        function (_ref2) {
+          var scaleX = _ref2.scaleX,
+              scaleY = _ref2.scaleY;
+          return (0, _react.cloneElement)(_this4.props.children, _extends({}, _this4.props.children.props || {}, {
+            style: _extends({}, _this4.props.children.props && _this4.props.children.props.style || {}, {
+              transform: 'translate3d(' + _x + 'px, ' + _y + 'px, 0) scaleX(' + scaleX + ') scaleY(' + scaleY + ')',
+              WebkitTransform: 'translate3d(' + _x + 'px, ' + _y + 'px, 0) scaleX(' + scaleX + ') scaleY(' + scaleY + ')',
+              position: 'absolute'
+            })
+          }));
         }
-    }, {
-        key: 'reverse',
-        value: function reverse() {
-            var _this3 = this;
+      );
+    }
+  }]);
 
-            this.timerIds.forEach(function (id) {
-                if (id) clearTimeout(id);
-            });
-            this.timerIds[0] = setTimeout(function () {
-                _this3.timerIds[0] = null;
-                _this3.props.onCloseAnimationEnd(_this3.props.name);
-            }, 80);
-            this.setState({ sequence: 0 });
-        }
-    }, {
-        key: 'render',
-        value: function render() {
-            var _this4 = this;
-
-            var _props = this.props,
-                x = _props.x,
-                y = _props.y,
-                reverse = _props.reverse,
-                type = _props.type;
-
-            var _x = reverse ? -1 * x : x;
-            var _y = type === 'vertical' && reverse ? -1 * y : y;
-            if (!this.props.children) return null;
-            return _react2.default.createElement(
-                _reactMotion.Motion,
-                { style: this.sequenceParams[this.state.sequence] },
-                function (_ref2) {
-                    var scaleX = _ref2.scaleX,
-                        scaleY = _ref2.scaleY;
-                    return (0, _react.cloneElement)(_this4.props.children, _extends({}, _this4.props.children.props || {}, {
-                        style: _extends({}, _this4.props.children.props && _this4.props.children.props.style || {}, {
-                            transform: 'translate3d(' + _x + 'px, ' + _y + 'px, 0) scaleX(' + scaleX + ') scaleY(' + scaleY + ')',
-                            WebkitTransform: 'translate3d(' + _x + 'px, ' + _y + 'px, 0) scaleX(' + scaleX + ') scaleY(' + scaleY + ')',
-                            position: 'absolute'
-                        })
-                    }));
-                }
-            );
-        }
-    }]);
-
-    return MenuItem;
+  return MenuItem;
 }(_react.Component);
 
 MenuItem.propTypes = {
-    x: _react.PropTypes.number.isRequired,
-    y: _react.PropTypes.number.isRequired,
-    name: _react.PropTypes.string.isRequired,
-    onOpenAnimationEnd: _react.PropTypes.func,
-    onCloseAnimationEnd: _react.PropTypes.func,
-    bumpy: _react.PropTypes.bool.isRequired,
-    speedOpen: _react.PropTypes.number,
-    openSpeed: _react.PropTypes.number,
-    reverse: _react.PropTypes.bool,
-    type: _react.PropTypes.oneOf(['horizontal', 'vertical', 'circle']).isRequired
+  x: _react.PropTypes.number.isRequired,
+  y: _react.PropTypes.number.isRequired,
+  name: _react.PropTypes.string.isRequired,
+  onOpenAnimationEnd: _react.PropTypes.func,
+  onCloseAnimationEnd: _react.PropTypes.func,
+  bumpy: _react.PropTypes.bool.isRequired,
+  speedOpen: _react.PropTypes.number,
+  openSpeed: _react.PropTypes.number,
+  reverse: _react.PropTypes.bool,
+  type: _react.PropTypes.oneOf(['horizontal', 'vertical', 'circle']).isRequired
 };
 MenuItem.defaultProps = {
-    onOpenAnimationEnd: function onOpenAnimationEnd() {},
-    onCloseAnimationEnd: function onCloseAnimationEnd() {}
+  onOpenAnimationEnd: function onOpenAnimationEnd() {},
+  onCloseAnimationEnd: function onCloseAnimationEnd() {}
 };
 exports.default = MenuItem;
 

--- a/docs/dist/bundle.js
+++ b/docs/dist/bundle.js
@@ -19,13 +19,13 @@ exports.default = function () {
     return _react2.default.createElement(
         _src2.default,
         {
-            type: 'circle',
+            type: 'vertical',
             margin: 120,
             y: 0,
-            distFactor: 0.5,
             bumpy: false,
             x: 0,
             openSpeed: 60,
+            wing: true,
             reverse: true
         },
         _react2.default.createElement(
@@ -22203,7 +22203,7 @@ var MotionMenu = function (_Component) {
     }, {
         key: 'getDistance',
         value: function getDistance(i) {
-            return this.props.wing ? (parseInt(i / 2, 10) + 1) * this.props.margin * (i % 2 || -1) : this.props.margin * (i + 1) * this.props.distFactor;
+            return this.props.wing ? (parseInt(i / 2, 10) + 1) * this.props.margin * (i % 2 || -1) : this.props.margin * (i + 1);
         }
     }, {
         key: 'getX',
@@ -22350,7 +22350,6 @@ MotionMenu.propTypes = {
     onOpen: _react.PropTypes.func,
     className: _react.PropTypes.string,
     bumpy: _react.PropTypes.bool,
-    distFactor: _react.PropTypes.number,
     openSpeed: _react.PropTypes.number,
     reverse: _react.PropTypes.bool
 };
@@ -22361,7 +22360,6 @@ MotionMenu.defaultProps = {
     onClose: function onClose() {},
     onOpen: function onOpen() {},
     bumpy: false,
-    distFactor: 0.5,
     openSpeed: 60,
     reverse: false
 };

--- a/docs/dist/bundle.js
+++ b/docs/dist/bundle.js
@@ -2,7 +2,7 @@
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
-  value: true
+    value: true
 });
 
 var _react = require('react');
@@ -16,55 +16,59 @@ var _src2 = _interopRequireDefault(_src);
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 exports.default = function () {
-  return _react2.default.createElement(
-    _src2.default,
-    {
-      type: 'circle',
-      margin: 120,
-      y: 0,
-      x: 0
-    },
-    _react2.default.createElement(
-      'div',
-      { className: 'button' },
-      _react2.default.createElement('i', { className: 'fa fa-bars' })
-    ),
-    _react2.default.createElement(
-      'div',
-      { className: 'button' },
-      _react2.default.createElement('i', { className: 'fa fa-cogs' })
-    ),
-    _react2.default.createElement(
-      'div',
-      { className: 'button' },
-      _react2.default.createElement('i', { className: 'fa fa-cloud' })
-    ),
-    _react2.default.createElement(
-      'div',
-      { className: 'button' },
-      _react2.default.createElement('i', { className: 'fa fa-home' })
-    ),
-    _react2.default.createElement(
-      'div',
-      { className: 'button' },
-      _react2.default.createElement('i', { className: 'fa fa-flash' })
-    ),
-    _react2.default.createElement(
-      'div',
-      { className: 'button' },
-      _react2.default.createElement('i', { className: 'fa fa-heart' })
-    ),
-    _react2.default.createElement(
-      'div',
-      { className: 'button' },
-      _react2.default.createElement('i', { className: 'fa fa-globe' })
-    ),
-    _react2.default.createElement(
-      'div',
-      { className: 'button' },
-      _react2.default.createElement('i', { className: 'fa fa-plug' })
-    )
-  );
+    return _react2.default.createElement(
+        _src2.default,
+        {
+            type: 'horizontal',
+            margin: 120,
+            y: 0,
+            distFactor: 0.5,
+            bumpy: false,
+            x: 0,
+            openSpeed: 60,
+            reverse: true
+        },
+        _react2.default.createElement(
+            'div',
+            { className: 'button' },
+            _react2.default.createElement('i', { className: 'fa fa-bars' })
+        ),
+        _react2.default.createElement(
+            'div',
+            { className: 'button' },
+            _react2.default.createElement('i', { className: 'fa fa-cogs' })
+        ),
+        _react2.default.createElement(
+            'div',
+            { className: 'button' },
+            _react2.default.createElement('i', { className: 'fa fa-cloud' })
+        ),
+        _react2.default.createElement(
+            'div',
+            { className: 'button' },
+            _react2.default.createElement('i', { className: 'fa fa-home' })
+        ),
+        _react2.default.createElement(
+            'div',
+            { className: 'button' },
+            _react2.default.createElement('i', { className: 'fa fa-flash' })
+        ),
+        _react2.default.createElement(
+            'div',
+            { className: 'button' },
+            _react2.default.createElement('i', { className: 'fa fa-heart' })
+        ),
+        _react2.default.createElement(
+            'div',
+            { className: 'button' },
+            _react2.default.createElement('i', { className: 'fa fa-globe' })
+        ),
+        _react2.default.createElement(
+            'div',
+            { className: 'button' },
+            _react2.default.createElement('i', { className: 'fa fa-plug' })
+        )
+    );
 };
 
 },{"../../src":195,"react":193}],2:[function(require,module,exports){
@@ -1195,8 +1199,15 @@ if (process.env.NODE_ENV !== 'production') {
 module.exports = warning;
 }).call(this,require('_process'))
 },{"./emptyFunction":10,"_process":28}],26:[function(require,module,exports){
+/*
+object-assign
+(c) Sindre Sorhus
+@license MIT
+*/
+
 'use strict';
 /* eslint-disable no-unused-vars */
+var getOwnPropertySymbols = Object.getOwnPropertySymbols;
 var hasOwnProperty = Object.prototype.hasOwnProperty;
 var propIsEnumerable = Object.prototype.propertyIsEnumerable;
 
@@ -1217,7 +1228,7 @@ function shouldUseNative() {
 		// Detect buggy property enumeration order in older V8 versions.
 
 		// https://bugs.chromium.org/p/v8/issues/detail?id=4118
-		var test1 = new String('abc');  // eslint-disable-line
+		var test1 = new String('abc');  // eslint-disable-line no-new-wrappers
 		test1[5] = 'de';
 		if (Object.getOwnPropertyNames(test1)[0] === '5') {
 			return false;
@@ -1246,7 +1257,7 @@ function shouldUseNative() {
 		}
 
 		return true;
-	} catch (e) {
+	} catch (err) {
 		// We don't expect any of the above to throw, but better to be safe.
 		return false;
 	}
@@ -1266,8 +1277,8 @@ module.exports = shouldUseNative() ? Object.assign : function (target, source) {
 			}
 		}
 
-		if (Object.getOwnPropertySymbols) {
-			symbols = Object.getOwnPropertySymbols(from);
+		if (getOwnPropertySymbols) {
+			symbols = getOwnPropertySymbols(from);
 			for (var i = 0; i < symbols.length; i++) {
 				if (propIsEnumerable.call(from, symbols[i])) {
 					to[symbols[i]] = from[symbols[i]];
@@ -5328,17 +5339,6 @@ var fourArgumentPooler = function (a1, a2, a3, a4) {
   }
 };
 
-var fiveArgumentPooler = function (a1, a2, a3, a4, a5) {
-  var Klass = this;
-  if (Klass.instancePool.length) {
-    var instance = Klass.instancePool.pop();
-    Klass.call(instance, a1, a2, a3, a4, a5);
-    return instance;
-  } else {
-    return new Klass(a1, a2, a3, a4, a5);
-  }
-};
-
 var standardReleaser = function (instance) {
   var Klass = this;
   !(instance instanceof Klass) ? process.env.NODE_ENV !== 'production' ? invariant(false, 'Trying to release an instance into a pool of a different type.') : _prodInvariant('25') : void 0;
@@ -5378,8 +5378,7 @@ var PooledClass = {
   oneArgumentPooler: oneArgumentPooler,
   twoArgumentPooler: twoArgumentPooler,
   threeArgumentPooler: threeArgumentPooler,
-  fourArgumentPooler: fourArgumentPooler,
-  fiveArgumentPooler: fiveArgumentPooler
+  fourArgumentPooler: fourArgumentPooler
 };
 
 module.exports = PooledClass;
@@ -6182,7 +6181,7 @@ var ReactCompositeComponent = {
       // Since plain JS classes are defined without any special initialization
       // logic, we can not catch common errors early. Therefore, we have to
       // catch them here, at initialization time, instead.
-      process.env.NODE_ENV !== 'production' ? warning(!inst.getInitialState || inst.getInitialState.isReactClassApproved, 'getInitialState was defined on %s, a plain JavaScript class. ' + 'This is only supported for classes created using React.createClass. ' + 'Did you mean to define a state property instead?', this.getName() || 'a component') : void 0;
+      process.env.NODE_ENV !== 'production' ? warning(!inst.getInitialState || inst.getInitialState.isReactClassApproved || inst.state, 'getInitialState was defined on %s, a plain JavaScript class. ' + 'This is only supported for classes created using React.createClass. ' + 'Did you mean to define a state property instead?', this.getName() || 'a component') : void 0;
       process.env.NODE_ENV !== 'production' ? warning(!inst.getDefaultProps || inst.getDefaultProps.isReactClassApproved, 'getDefaultProps was defined on %s, a plain JavaScript class. ' + 'This is only supported for classes created using React.createClass. ' + 'Use a static property to define defaultProps instead.', this.getName() || 'a component') : void 0;
       process.env.NODE_ENV !== 'production' ? warning(!inst.propTypes, 'propTypes was defined as an instance property on %s. Use a static ' + 'property to define propTypes instead.', this.getName() || 'a component') : void 0;
       process.env.NODE_ENV !== 'production' ? warning(!inst.contextTypes, 'contextTypes was defined as an instance property on %s. Use a ' + 'static property to define contextTypes instead.', this.getName() || 'a component') : void 0;
@@ -7648,12 +7647,18 @@ ReactDOMComponent.Mixin = {
     } else {
       var contentToUse = CONTENT_TYPES[typeof props.children] ? props.children : null;
       var childrenToUse = contentToUse != null ? null : props.children;
+      // TODO: Validate that text is allowed as a child of this node
       if (contentToUse != null) {
-        // TODO: Validate that text is allowed as a child of this node
-        if (process.env.NODE_ENV !== 'production') {
-          setAndValidateContentChildDev.call(this, contentToUse);
+        // Avoid setting textContent when the text is empty. In IE11 setting
+        // textContent on a text area will cause the placeholder to not
+        // show within the textarea until it has been focused and blurred again.
+        // https://github.com/facebook/react/issues/6731#issuecomment-254874553
+        if (contentToUse !== '') {
+          if (process.env.NODE_ENV !== 'production') {
+            setAndValidateContentChildDev.call(this, contentToUse);
+          }
+          DOMLazyTree.queueText(lazyTree, contentToUse);
         }
-        DOMLazyTree.queueText(lazyTree, contentToUse);
       } else if (childrenToUse != null) {
         var mountImages = this.mountChildren(childrenToUse, transaction, context);
         for (var i = 0; i < mountImages.length; i++) {
@@ -8005,6 +8010,13 @@ var Flags = ReactDOMComponentFlags;
 var internalInstanceKey = '__reactInternalInstance$' + Math.random().toString(36).slice(2);
 
 /**
+ * Check if a given node should be cached.
+ */
+function shouldPrecacheNode(node, nodeID) {
+  return node.nodeType === 1 && node.getAttribute(ATTR_NAME) === String(nodeID) || node.nodeType === 8 && node.nodeValue === ' react-text: ' + nodeID + ' ' || node.nodeType === 8 && node.nodeValue === ' react-empty: ' + nodeID + ' ';
+}
+
+/**
  * Drill down (through composites and empty components) until we get a host or
  * host text component.
  *
@@ -8069,7 +8081,7 @@ function precacheChildNodes(inst, node) {
     }
     // We assume the child nodes are in the same order as the child instances.
     for (; childNode !== null; childNode = childNode.nextSibling) {
-      if (childNode.nodeType === 1 && childNode.getAttribute(ATTR_NAME) === String(childID) || childNode.nodeType === 8 && childNode.nodeValue === ' react-text: ' + childID + ' ' || childNode.nodeType === 8 && childNode.nodeValue === ' react-empty: ' + childID + ' ') {
+      if (shouldPrecacheNode(childNode, childID)) {
         precacheNode(childInst, childNode);
         continue outer;
       }
@@ -8477,7 +8489,17 @@ var ReactDOMInput = {
       }
     } else {
       if (props.value == null && props.defaultValue != null) {
-        node.defaultValue = '' + props.defaultValue;
+        // In Chrome, assigning defaultValue to certain input types triggers input validation.
+        // For number inputs, the display value loses trailing decimal points. For email inputs,
+        // Chrome raises "The specified value <x> is not a valid email address".
+        //
+        // Here we check to see if the defaultValue has actually changed, avoiding these problems
+        // when the user is inputting text
+        //
+        // https://github.com/facebook/react/issues/7253
+        if (node.defaultValue !== '' + props.defaultValue) {
+          node.defaultValue = '' + props.defaultValue;
+        }
       }
       if (props.checked == null && props.defaultChecked != null) {
         node.defaultChecked = !!props.defaultChecked;
@@ -9572,9 +9594,15 @@ var ReactDOMTextarea = {
     // This is in postMount because we need access to the DOM node, which is not
     // available until after the component has mounted.
     var node = ReactDOMComponentTree.getNodeFromInstance(inst);
+    var textContent = node.textContent;
 
-    // Warning: node.value may be the empty string at this point (IE11) if placeholder is set.
-    node.value = node.textContent; // Detach value from defaultValue
+    // Only set node.value if textContent is equal to the expected
+    // initial value. In IE10/IE11 there is a bug where the placeholder attribute
+    // will populate textContent as well.
+    // https://developer.microsoft.com/microsoft-edge/platform/issues/101525/
+    if (textContent === inst._wrapperState.initialValue) {
+      node.value = textContent;
+    }
   }
 };
 
@@ -10709,14 +10737,11 @@ module.exports = ReactFeatureFlags;
 
 'use strict';
 
-var _prodInvariant = require('./reactProdInvariant'),
-    _assign = require('object-assign');
+var _prodInvariant = require('./reactProdInvariant');
 
 var invariant = require('fbjs/lib/invariant');
 
 var genericComponentClass = null;
-// This registry keeps track of wrapper classes around host tags.
-var tagToComponentClass = {};
 var textComponentClass = null;
 
 var ReactHostComponentInjection = {
@@ -10729,11 +10754,6 @@ var ReactHostComponentInjection = {
   // rendered as props.
   injectTextComponentClass: function (componentClass) {
     textComponentClass = componentClass;
-  },
-  // This accepts a keyed object with classes as values. Each key represents a
-  // tag. That particular tag will use this class instead of the generic one.
-  injectComponentClasses: function (componentClasses) {
-    _assign(tagToComponentClass, componentClasses);
   }
 };
 
@@ -10773,7 +10793,7 @@ var ReactHostComponent = {
 
 module.exports = ReactHostComponent;
 }).call(this,require('_process'))
-},{"./reactProdInvariant":150,"_process":28,"fbjs/lib/invariant":18,"object-assign":26}],88:[function(require,module,exports){
+},{"./reactProdInvariant":150,"_process":28,"fbjs/lib/invariant":18}],88:[function(require,module,exports){
 /**
  * Copyright 2016-present, Facebook, Inc.
  * All rights reserved.
@@ -13468,7 +13488,7 @@ module.exports = ReactUpdates;
 
 'use strict';
 
-module.exports = '15.4.1';
+module.exports = '15.4.2';
 },{}],109:[function(require,module,exports){
 /**
  * Copyright 2013-present, Facebook, Inc.
@@ -16490,7 +16510,17 @@ function instantiateReactComponent(node, shouldHaveDebugID) {
     instance = ReactEmptyComponent.create(instantiateReactComponent);
   } else if (typeof node === 'object') {
     var element = node;
-    !(element && (typeof element.type === 'function' || typeof element.type === 'string')) ? process.env.NODE_ENV !== 'production' ? invariant(false, 'Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: %s.%s', element.type == null ? element.type : typeof element.type, getDeclarationErrorAddendum(element._owner)) : _prodInvariant('130', element.type == null ? element.type : typeof element.type, getDeclarationErrorAddendum(element._owner)) : void 0;
+    var type = element.type;
+    if (typeof type !== 'function' && typeof type !== 'string') {
+      var info = '';
+      if (process.env.NODE_ENV !== 'production') {
+        if (type === undefined || typeof type === 'object' && type !== null && Object.keys(type).length === 0) {
+          info += ' You likely forgot to export your component from the file ' + 'it\'s defined in.';
+        }
+      }
+      info += getDeclarationErrorAddendum(element._owner);
+      !false ? process.env.NODE_ENV !== 'production' ? invariant(false, 'Element type is invalid: expected a string (for built-in components) or a class/function (for composite components) but got: %s.%s', type == null ? type : typeof type, info) : _prodInvariant('130', type == null ? type : typeof type, info) : void 0;
+    }
 
     // Special case string values
     if (typeof element.type === 'string') {
@@ -20968,7 +20998,14 @@ var ReactElementValidator = {
     // We warn in this case but don't throw. We expect the element creation to
     // succeed and there will likely be errors in render.
     if (!validType) {
-      process.env.NODE_ENV !== 'production' ? warning(false, 'React.createElement: type should not be null, undefined, boolean, or ' + 'number. It should be a string (for DOM elements) or a ReactClass ' + '(for composite components).%s', getDeclarationErrorAddendum()) : void 0;
+      if (typeof type !== 'function' && typeof type !== 'string') {
+        var info = '';
+        if (type === undefined || typeof type === 'object' && type !== null && Object.keys(type).length === 0) {
+          info += ' You likely forgot to export your component from the file ' + 'it\'s defined in.';
+        }
+        info += getDeclarationErrorAddendum();
+        process.env.NODE_ENV !== 'production' ? warning(false, 'React.createElement: type is invalid -- expected a string (for ' + 'built-in components) or a class/function (for composite ' + 'components) but got: %s.%s', type == null ? type : typeof type, info) : void 0;
+      }
     }
 
     var element = ReactElement.createElement.apply(this, arguments);
@@ -21993,12 +22030,21 @@ var MenuButton = function (_Component) {
     _this.state = {
       sequence: 0
     };
-    _this.sequenceParams = [{
+    _this.sequenceParams = _this.props.bumpy ? [{
       scaleX: (0, _reactMotion.spring)(1, { stiffness: 1500, damping: 10 }),
       scaleY: (0, _reactMotion.spring)(1, { stiffness: 1500, damping: 10 })
     }, {
       scaleX: (0, _reactMotion.spring)(0.6, { stiffness: 1500, damping: 50 }),
       scaleY: (0, _reactMotion.spring)(0.6, { stiffness: 1500, damping: 50 })
+    }, {
+      scaleX: (0, _reactMotion.spring)(1, { stiffness: 1500, damping: 10 }),
+      scaleY: (0, _reactMotion.spring)(1, { stiffness: 1500, damping: 10 })
+    }] : [{
+      scaleX: (0, _reactMotion.spring)(1, { stiffness: 1500, damping: 10 }),
+      scaleY: (0, _reactMotion.spring)(1, { stiffness: 1500, damping: 10 })
+    }, {
+      scaleX: (0, _reactMotion.spring)(1, { stiffness: 200, damping: 50 }),
+      scaleY: (0, _reactMotion.spring)(1, { stiffness: 200, damping: 50 })
     }, {
       scaleX: (0, _reactMotion.spring)(1, { stiffness: 1500, damping: 10 }),
       scaleY: (0, _reactMotion.spring)(1, { stiffness: 1500, damping: 10 })
@@ -22047,7 +22093,7 @@ var MenuButton = function (_Component) {
               scaleY = _ref.scaleY;
           return (0, _react.cloneElement)(_this4.props.children, _extends({}, _this4.props.children.props || {}, {
             onClick: onClick,
-            style: _extends({}, _this4.props.children.props.style, {
+            style: _extends({}, _this4.props.children.props && _this4.props.children.props.style || {}, {
               transform: 'translate3d(' + x + 'px, ' + y + 'px, 0) scaleX(' + scaleX + ') scaleY(' + scaleY + ')',
               WebkitTransform: 'translate3d(' + x + 'px, ' + y + 'px, 0) scaleX(' + scaleX + ') scaleY(' + scaleY + ')',
               position: 'absolute'
@@ -22064,7 +22110,8 @@ var MenuButton = function (_Component) {
 MenuButton.propTypes = {
   x: _react.PropTypes.number.isRequired,
   y: _react.PropTypes.number.isRequired,
-  onClick: _react.PropTypes.func
+  onClick: _react.PropTypes.func,
+  bumpy: _react.PropTypes.bool
 };
 exports.default = MenuButton;
 
@@ -22072,7 +22119,7 @@ exports.default = MenuButton;
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
-  value: true
+    value: true
 });
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
@@ -22098,212 +22145,225 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
 var MotionMenu = function (_Component) {
-  _inherits(MotionMenu, _Component);
+    _inherits(MotionMenu, _Component);
 
-  function MotionMenu(props) {
-    _classCallCheck(this, MotionMenu);
+    function MotionMenu(props) {
+        _classCallCheck(this, MotionMenu);
 
-    var _this = _possibleConstructorReturn(this, (MotionMenu.__proto__ || Object.getPrototypeOf(MotionMenu)).call(this, props));
+        var _this = _possibleConstructorReturn(this, (MotionMenu.__proto__ || Object.getPrototypeOf(MotionMenu)).call(this, props));
 
-    _this.state = {
-      itemNumber: 1,
-      status: 'idle'
-    };
-    _this.items = [];
-    _this.onOpenEnd = _this.onOpenEnd.bind(_this);
-    _this.onCloseEnd = _this.onCloseEnd.bind(_this);
-    _this.onClick = _this.onClick.bind(_this);
-    return _this;
-  }
-
-  _createClass(MotionMenu, [{
-    key: 'onOpenEnd',
-    value: function onOpenEnd(name) {
-      if (this.state.action !== 'open') return;
-      if (this.state.itemNumber < this.props.children.length) {
-        this.items[this.state.itemNumber].start();
-        this.setState({
-          itemNumber: this.state.itemNumber + 1
-        });
-        return;
-      }
-      if (name === 'item' + (this.props.children.length - 1)) {
-        this.props.onOpen();
-      }
+        _this.state = {
+            itemNumber: 1,
+            status: 'idle'
+        };
+        _this.items = [];
+        _this.onOpenEnd = _this.onOpenEnd.bind(_this);
+        _this.onCloseEnd = _this.onCloseEnd.bind(_this);
+        _this.onClick = _this.onClick.bind(_this);
+        return _this;
     }
-  }, {
-    key: 'onCloseEnd',
-    value: function onCloseEnd(name) {
-      if (this.state.action === 'open') return;
-      if (this.state.itemNumber > 1) {
-        if (name === 'item1') {
-          this.props.onClose();
+
+    _createClass(MotionMenu, [{
+        key: 'onOpenEnd',
+        value: function onOpenEnd(name) {
+            if (this.state.action !== 'open') return;
+            if (this.state.itemNumber < this.props.children.length) {
+                this.items[this.state.itemNumber].start();
+                this.setState({
+                    itemNumber: this.state.itemNumber + 1
+                });
+                return;
+            }
+            if (name === 'item' + (this.props.children.length - 1)) {
+                this.props.onOpen();
+            }
         }
-        this.setState({
-          itemNumber: this.state.itemNumber - 1
-        });
-      }
-    }
-  }, {
-    key: 'onClick',
-    value: function onClick() {
-      if (this.state.action === 'open') {
-        this.closeItems();
-      } else {
-        this.openItem();
-      }
-    }
-  }, {
-    key: 'getDistance',
-    value: function getDistance(i) {
-      return this.props.wing ? (parseInt(i / 2, 10) + 1) * this.props.margin * (i % 2 || -1) : this.props.margin * (i + 1);
-    }
-  }, {
-    key: 'getX',
-    value: function getX(i, x) {
-      var _props = this.props,
-          type = _props.type,
-          margin = _props.margin,
-          children = _props.children;
+    }, {
+        key: 'onCloseEnd',
+        value: function onCloseEnd(name) {
+            if (this.state.action === 'open') return;
+            if (this.state.itemNumber > 1) {
+                if (name === 'item1') {
+                    this.props.onClose();
+                }
+                this.setState({
+                    itemNumber: this.state.itemNumber - 1
+                });
+            }
+        }
+    }, {
+        key: 'onClick',
+        value: function onClick() {
+            if (this.state.action === 'open') {
+                this.closeItems();
+            } else {
+                this.openItem();
+            }
+        }
+    }, {
+        key: 'getDistance',
+        value: function getDistance(i) {
+            return this.props.wing ? (parseInt(i / 2, 10) + 1) * this.props.margin * (i % 2 || -1) : this.props.margin * (i + 1) * this.props.distFactor;
+        }
+    }, {
+        key: 'getX',
+        value: function getX(i, x) {
+            var _props = this.props,
+                type = _props.type,
+                margin = _props.margin,
+                children = _props.children;
 
-      if (type === 'horizontal') {
-        return this.getDistance(i) + x;
-      }
-      if (type === 'circle') {
-        return x + margin * Math.cos(Math.PI * 2 * i / (children.length - 1));
-      }
-      return x;
-    }
-  }, {
-    key: 'getY',
-    value: function getY(i, y) {
-      var _props2 = this.props,
-          type = _props2.type,
-          margin = _props2.margin,
-          children = _props2.children;
+            if (type === 'horizontal') {
+                return this.getDistance(i) + x;
+            }
+            if (type === 'circle') {
+                return x + margin * Math.cos(Math.PI * 2 * i / (children.length - 1));
+            }
+            return x;
+        }
+    }, {
+        key: 'getY',
+        value: function getY(i, y) {
+            var _props2 = this.props,
+                type = _props2.type,
+                margin = _props2.margin,
+                children = _props2.children;
 
-      if (type === 'vertical') {
-        return this.getDistance(i) + y;
-      }
-      if (type === 'circle') {
-        return y + margin * Math.sin(Math.PI * 2 * i / (children.length - 1));
-      }
-      return y;
-    }
-  }, {
-    key: 'getItems',
-    value: function getItems() {
-      var _this2 = this;
+            if (type === 'vertical') {
+                return this.getDistance(i) + y;
+            }
+            if (type === 'circle') {
+                return y + margin * Math.sin(Math.PI * 2 * i / (children.length - 1));
+            }
+            return y;
+        }
+    }, {
+        key: 'getItems',
+        value: function getItems() {
+            var _this2 = this;
 
-      var _props3 = this.props,
-          x = _props3.x,
-          y = _props3.y;
+            var _props3 = this.props,
+                x = _props3.x,
+                y = _props3.y,
+                bumpy = _props3.bumpy;
 
-      return Array.from(Array(this.state.itemNumber).keys()).reverse().map(function (i) {
-        return _react2.default.createElement(
-          _item2.default,
-          {
-            direction: _this2.props.type,
-            key: i,
-            ref: function ref(c) {
-              _this2.items[i + 1] = c;
-            },
-            name: 'item' + (i + 1),
-            onOpenAnimationEnd: _this2.onOpenEnd,
-            onCloseAnimationEnd: _this2.onCloseEnd,
-            x: _this2.getX(i, x),
-            y: _this2.getY(i, y)
-          },
-          _this2.props.children[i + 1]
-        );
-      });
-    }
-  }, {
-    key: 'closeItems',
-    value: function closeItems() {
-      var _this3 = this;
+            return Array.from(Array(this.state.itemNumber).keys()).reverse().map(function (i) {
+                return _react2.default.createElement(
+                    _item2.default,
+                    {
+                        direction: _this2.props.type,
+                        key: i,
+                        ref: function ref(c) {
+                            _this2.items[i + 1] = c;
+                        },
+                        name: 'item' + (i + 1),
+                        onOpenAnimationEnd: _this2.onOpenEnd,
+                        onCloseAnimationEnd: _this2.onCloseEnd,
+                        x: _this2.getX(i, x),
+                        y: _this2.getY(i, y),
+                        bumpy: bumpy,
+                        openSpeed: _this2.props.openSpeed,
+                        reverse: _this2.props.reverse
+                    },
+                    _this2.props.children[i + 1]
+                );
+            });
+        }
+    }, {
+        key: 'closeItems',
+        value: function closeItems() {
+            var _this3 = this;
 
-      this.setState({ action: 'close' });
-      this.button.reverse();
-      Array.from(Array(this.state.itemNumber).keys()).reverse().forEach(function (i) {
-        return _this3.items[i + 1].reverse();
-      });
-    }
-  }, {
-    key: 'close',
-    value: function close() {
-      if (this.state.action !== 'open') return;
-      this.closeItems();
-    }
-  }, {
-    key: 'open',
-    value: function open() {
-      if (this.state.action === 'open') return;
-      this.openItem();
-    }
-  }, {
-    key: 'openItem',
-    value: function openItem() {
-      this.setState({ action: 'open' });
-      this.button.start();
-      this.items[this.state.itemNumber].start();
-    }
-  }, {
-    key: 'render',
-    value: function render() {
-      return _react2.default.createElement(
-        'div',
-        {
-          style: this.props.style,
-          className: this.props.className
-        },
-        _react2.default.createElement(
-          'div',
-          { style: { position: 'relative' } },
-          this.menuButton,
-          this.getItems()
-        )
-      );
-    }
-  }, {
-    key: 'menuButton',
-    get: function get() {
-      var _this4 = this;
+            this.setState({ action: 'close' });
+            this.button.reverse();
+            Array.from(Array(this.state.itemNumber).keys()).reverse().forEach(function (i) {
+                return _this3.items[i + 1].reverse();
+            });
+        }
+    }, {
+        key: 'close',
+        value: function close() {
+            if (this.state.action !== 'open') return;
+            this.closeItems();
+        }
+    }, {
+        key: 'open',
+        value: function open() {
+            if (this.state.action === 'open') return;
+            this.openItem();
+        }
+    }, {
+        key: 'openItem',
+        value: function openItem() {
+            this.setState({ action: 'open' });
+            this.button.start();
+            this.items[this.state.itemNumber].start();
+        }
+    }, {
+        key: 'render',
+        value: function render() {
+            return _react2.default.createElement(
+                'div',
+                {
+                    style: this.props.style,
+                    className: this.props.className
+                },
+                _react2.default.createElement(
+                    'div',
+                    { style: { position: 'relative' } },
+                    this.menuButton,
+                    this.getItems()
+                )
+            );
+        }
+    }, {
+        key: 'menuButton',
+        get: function get() {
+            var _this4 = this;
 
-      return _react2.default.createElement(
-        _button2.default,
-        {
-          ref: function ref(c) {
-            _this4.button = c;
-          },
-          onClick: this.onClick,
-          x: this.props.x,
-          y: this.props.y
-        },
-        this.props.children[0]
-      );
-    }
-  }]);
+            return _react2.default.createElement(
+                _button2.default,
+                {
+                    ref: function ref(c) {
+                        _this4.button = c;
+                    },
+                    onClick: this.onClick,
+                    x: this.props.x,
+                    y: this.props.y,
+                    bumpy: this.props.bumpy
+                },
+                this.props.children[0]
+            );
+        }
+    }]);
 
-  return MotionMenu;
+    return MotionMenu;
 }(_react.Component);
 
 MotionMenu.propTypes = {
-  margin: _react.PropTypes.number.isRequired,
-  type: _react.PropTypes.oneOf(['horizontal', 'vertical', 'circle']).isRequired,
-  wing: _react.PropTypes.bool,
-  x: _react.PropTypes.number,
-  y: _react.PropTypes.number,
-  onClose: _react.PropTypes.func,
-  onOpen: _react.PropTypes.func,
-  className: _react.PropTypes.string
+    margin: _react.PropTypes.number.isRequired,
+    type: _react.PropTypes.oneOf(['horizontal', 'vertical', 'circle']).isRequired,
+    wing: _react.PropTypes.bool,
+    x: _react.PropTypes.number,
+    y: _react.PropTypes.number,
+    onClose: _react.PropTypes.func,
+    onOpen: _react.PropTypes.func,
+    className: _react.PropTypes.string,
+    bumpy: _react.PropTypes.bool,
+    distFactor: _react.PropTypes.number,
+    openSpeed: _react.PropTypes.number,
+    reverse: _react.PropTypes.bool
 };
 MotionMenu.defaultProps = {
-  x: 0,
-  y: 0,
-  style: {},
-  onClose: function onClose() {},
-  onOpen: function onOpen() {}
+    x: 0,
+    y: 0,
+    style: {},
+    onClose: function onClose() {},
+    onOpen: function onOpen() {},
+    bumpy: false,
+    distFactor: 0.5,
+    openSpeed: 60,
+    reverse: false
 };
 exports.default = MotionMenu;
 
@@ -22311,7 +22371,7 @@ exports.default = MotionMenu;
 'use strict';
 
 Object.defineProperty(exports, "__esModule", {
-  value: true
+    value: true
 });
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
@@ -22332,114 +22392,141 @@ function _possibleConstructorReturn(self, call) { if (!self) { throw new Referen
 
 function _inherits(subClass, superClass) { if (typeof superClass !== "function" && superClass !== null) { throw new TypeError("Super expression must either be null or a function, not " + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) Object.setPrototypeOf ? Object.setPrototypeOf(subClass, superClass) : subClass.__proto__ = superClass; }
 
-var createParams = function createParams(_ref) {
-  var x = _ref.x,
-      y = _ref.y;
-  return [{
-    scaleX: (0, _reactMotion.spring)(0, { stiffness: 1500, damping: 100 }),
-    scaleY: (0, _reactMotion.spring)(0, { stiffness: 1500, damping: 100 }),
-    x: (0, _reactMotion.spring)(x, { stiffness: 1500, damping: 50 }),
-    y: (0, _reactMotion.spring)(y, { stiffness: 1500, damping: 50 })
-  }, {
-    scaleX: (0, _reactMotion.spring)(1.6, { stiffness: 1500, damping: 150 }),
-    scaleY: (0, _reactMotion.spring)(0.7, { stiffness: 1500, damping: 150 }),
-    x: (0, _reactMotion.spring)(x, { stiffness: 1500, damping: 100 }),
-    y: (0, _reactMotion.spring)(y, { stiffness: 1500, damping: 100 })
-  }, {
-    scaleX: (0, _reactMotion.spring)(1, { stiffness: 1500, damping: 18 }),
-    scaleY: (0, _reactMotion.spring)(1, { stiffness: 1500, damping: 18 }),
-    x: (0, _reactMotion.spring)(x, { stiffness: 1500, damping: 100 }),
-    y: (0, _reactMotion.spring)(y, { stiffness: 1500, damping: 100 })
-  }];
+var createSmoothParams = function createSmoothParams(_ref) {
+    var x = _ref.x,
+        y = _ref.y;
+    return [{
+        scaleX: (0, _reactMotion.spring)(0, { stiffness: 1500, damping: 100 }),
+        scaleY: (0, _reactMotion.spring)(0, { stiffness: 1500, damping: 100 }),
+        x: (0, _reactMotion.spring)(x, { stiffness: 1500, damping: 50 }),
+        y: (0, _reactMotion.spring)(y, { stiffness: 1500, damping: 50 })
+    }, {
+        scaleX: (0, _reactMotion.spring)(0.5, { stiffness: 120, damping: 20 }),
+        scaleY: (0, _reactMotion.spring)(0.5, { stiffness: 120, damping: 20 }),
+        x: (0, _reactMotion.spring)(x, { stiffness: 120, damping: 20 }),
+        y: (0, _reactMotion.spring)(y, { stiffness: 120, damping: 20 })
+    }, {
+        scaleX: (0, _reactMotion.spring)(1, { stiffness: 120, damping: 20 }),
+        scaleY: (0, _reactMotion.spring)(1, { stiffness: 120, damping: 20 }),
+        x: (0, _reactMotion.spring)(x, { stiffness: 120, damping: 20 }),
+        y: (0, _reactMotion.spring)(y, { stiffness: 120, damping: 20 })
+    }];
+};
+
+var createBumpyParams = function createBumpyParams(x, y) {
+    return [{
+        scaleX: (0, _reactMotion.spring)(0, { stiffness: 1500, damping: 100 }),
+        scaleY: (0, _reactMotion.spring)(0, { stiffness: 1500, damping: 100 }),
+        x: (0, _reactMotion.spring)(x, { stiffness: 1500, damping: 50 }),
+        y: (0, _reactMotion.spring)(y, { stiffness: 1500, damping: 50 })
+    }, {
+        scaleX: (0, _reactMotion.spring)(1.6, { stiffness: 1500, damping: 150 }),
+        scaleY: (0, _reactMotion.spring)(0.7, { stiffness: 1500, damping: 150 }),
+        x: (0, _reactMotion.spring)(x, { stiffness: 1500, damping: 100 }),
+        y: (0, _reactMotion.spring)(y, { stiffness: 1500, damping: 100 })
+    }, {
+        scaleX: (0, _reactMotion.spring)(1, { stiffness: 1500, damping: 18 }),
+        scaleY: (0, _reactMotion.spring)(1, { stiffness: 1500, damping: 18 }),
+        x: (0, _reactMotion.spring)(x, { stiffness: 1500, damping: 100 }),
+        y: (0, _reactMotion.spring)(y, { stiffness: 1500, damping: 100 })
+    }];
 };
 
 var MenuItem = function (_Component) {
-  _inherits(MenuItem, _Component);
+    _inherits(MenuItem, _Component);
 
-  function MenuItem(props) {
-    _classCallCheck(this, MenuItem);
+    function MenuItem(props) {
+        _classCallCheck(this, MenuItem);
 
-    var _this = _possibleConstructorReturn(this, (MenuItem.__proto__ || Object.getPrototypeOf(MenuItem)).call(this, props));
+        var _this = _possibleConstructorReturn(this, (MenuItem.__proto__ || Object.getPrototypeOf(MenuItem)).call(this, props));
 
-    _this.timerIds = [];
-    _this.state = {
-      sequence: 0
-    };
-    _this.sequenceParams = createParams(props);
-    return _this;
-  }
+        _this.timerIds = [];
+        _this.state = {
+            sequence: 0
+        };
 
-  _createClass(MenuItem, [{
-    key: 'start',
-    value: function start() {
-      var _this2 = this;
-
-      this.timerIds[1] = setTimeout(function () {
-        _this2.setState({ sequence: 1 });
-        _this2.timerIds[1] = null;
-      }, 60);
-
-      this.timerIds[2] = setTimeout(function () {
-        _this2.setState({ sequence: 2 });
-        _this2.timerIds[2] = null;
-        _this2.props.onOpenAnimationEnd(_this2.props.name);
-      }, 80);
+        _this.sequenceParams = _this.props.bumpy ? createBumpyParams(props) : createSmoothParams(props);
+        return _this;
     }
-  }, {
-    key: 'reverse',
-    value: function reverse() {
-      var _this3 = this;
 
-      this.timerIds.forEach(function (id) {
-        if (id) clearTimeout(id);
-      });
-      this.timerIds[0] = setTimeout(function () {
-        _this3.timerIds[0] = null;
-        _this3.props.onCloseAnimationEnd(_this3.props.name);
-      }, 100);
-      this.setState({ sequence: 0 });
-    }
-  }, {
-    key: 'render',
-    value: function render() {
-      var _this4 = this;
+    _createClass(MenuItem, [{
+        key: 'start',
+        value: function start() {
+            var _this2 = this;
 
-      var _props = this.props,
-          x = _props.x,
-          y = _props.y;
+            this.timerIds[1] = setTimeout(function () {
+                _this2.setState({ sequence: 1 });
+                _this2.timerIds[1] = null;
+            }, this.props.openSpeed);
 
-      if (!this.props.children) return null;
-      return _react2.default.createElement(
-        _reactMotion.Motion,
-        { style: this.sequenceParams[this.state.sequence] },
-        function (_ref2) {
-          var scaleX = _ref2.scaleX,
-              scaleY = _ref2.scaleY;
-          return (0, _react.cloneElement)(_this4.props.children, _extends({}, _this4.props.children.props || {}, {
-            style: _extends({}, _this4.props.children.props.style, {
-              transform: 'translate3d(' + x + 'px, ' + y + 'px, 0) scaleX(' + scaleX + ') scaleY(' + scaleY + ')',
-              WebkitTransform: 'translate3d(' + x + 'px, ' + y + 'px, 0) scaleX(' + scaleX + ') scaleY(' + scaleY + ')',
-              position: 'absolute'
-            })
-          }));
+            this.timerIds[2] = setTimeout(function () {
+                _this2.setState({ sequence: 2 });
+                _this2.timerIds[2] = null;
+                _this2.props.onOpenAnimationEnd(_this2.props.name);
+            }, this.props.openSpeed);
         }
-      );
-    }
-  }]);
+    }, {
+        key: 'reverse',
+        value: function reverse() {
+            var _this3 = this;
 
-  return MenuItem;
+            this.timerIds.forEach(function (id) {
+                if (id) clearTimeout(id);
+            });
+            this.timerIds[0] = setTimeout(function () {
+                _this3.timerIds[0] = null;
+                _this3.props.onCloseAnimationEnd(_this3.props.name);
+            }, 80);
+            this.setState({ sequence: 0 });
+        }
+    }, {
+        key: 'render',
+        value: function render() {
+            var _this4 = this;
+
+            var _props = this.props,
+                x = _props.x,
+                y = _props.y,
+                reverse = _props.reverse;
+
+            var _x = reverse ? -1 * x : x;
+
+            if (!this.props.children) return null;
+            return _react2.default.createElement(
+                _reactMotion.Motion,
+                { style: this.sequenceParams[this.state.sequence] },
+                function (_ref2) {
+                    var scaleX = _ref2.scaleX,
+                        scaleY = _ref2.scaleY;
+                    return (0, _react.cloneElement)(_this4.props.children, _extends({}, _this4.props.children.props || {}, {
+                        style: _extends({}, _this4.props.children.props && _this4.props.children.props.style || {}, {
+                            transform: 'translate3d(' + _x + 'px, ' + y + 'px, 0) scaleX(' + scaleX + ') scaleY(' + scaleY + ')',
+                            WebkitTransform: 'translate3d(' + _x + 'px, ' + y + 'px, 0) scaleX(' + scaleX + ') scaleY(' + scaleY + ')',
+                            position: 'absolute'
+                        })
+                    }));
+                }
+            );
+        }
+    }]);
+
+    return MenuItem;
 }(_react.Component);
 
 MenuItem.propTypes = {
-  x: _react.PropTypes.number.isRequired,
-  y: _react.PropTypes.number.isRequired,
-  name: _react.PropTypes.string.isRequired,
-  onOpenAnimationEnd: _react.PropTypes.func,
-  onCloseAnimationEnd: _react.PropTypes.func
+    x: _react.PropTypes.number.isRequired,
+    y: _react.PropTypes.number.isRequired,
+    name: _react.PropTypes.string.isRequired,
+    onOpenAnimationEnd: _react.PropTypes.func,
+    onCloseAnimationEnd: _react.PropTypes.func,
+    bumpy: _react.PropTypes.bool.isRequired,
+    speedOpen: _react.PropTypes.number,
+    openSpeed: _react.PropTypes.number,
+    reverse: _react.PropTypes.bool
 };
 MenuItem.defaultProps = {
-  onOpenAnimationEnd: function onOpenAnimationEnd() {},
-  onCloseAnimationEnd: function onCloseAnimationEnd() {}
+    onOpenAnimationEnd: function onOpenAnimationEnd() {},
+    onCloseAnimationEnd: function onCloseAnimationEnd() {}
 };
 exports.default = MenuItem;
 

--- a/docs/dist/bundle.js
+++ b/docs/dist/bundle.js
@@ -19,7 +19,7 @@ exports.default = function () {
     return _react2.default.createElement(
         _src2.default,
         {
-            type: 'horizontal',
+            type: 'circle',
             margin: 120,
             y: 0,
             distFactor: 0.5,
@@ -22251,7 +22251,6 @@ var MotionMenu = function (_Component) {
                 return _react2.default.createElement(
                     _item2.default,
                     {
-                        direction: _this2.props.type,
                         key: i,
                         ref: function ref(c) {
                             _this2.items[i + 1] = c;
@@ -22263,7 +22262,8 @@ var MotionMenu = function (_Component) {
                         y: _this2.getY(i, y),
                         bumpy: bumpy,
                         openSpeed: _this2.props.openSpeed,
-                        reverse: _this2.props.reverse
+                        reverse: _this2.props.reverse,
+                        type: _this2.props.type
                     },
                     _this2.props.children[i + 1]
                 );
@@ -22487,10 +22487,11 @@ var MenuItem = function (_Component) {
             var _props = this.props,
                 x = _props.x,
                 y = _props.y,
-                reverse = _props.reverse;
+                reverse = _props.reverse,
+                type = _props.type;
 
             var _x = reverse ? -1 * x : x;
-
+            var _y = type === 'vertical' && reverse ? -1 * y : y;
             if (!this.props.children) return null;
             return _react2.default.createElement(
                 _reactMotion.Motion,
@@ -22500,8 +22501,8 @@ var MenuItem = function (_Component) {
                         scaleY = _ref2.scaleY;
                     return (0, _react.cloneElement)(_this4.props.children, _extends({}, _this4.props.children.props || {}, {
                         style: _extends({}, _this4.props.children.props && _this4.props.children.props.style || {}, {
-                            transform: 'translate3d(' + _x + 'px, ' + y + 'px, 0) scaleX(' + scaleX + ') scaleY(' + scaleY + ')',
-                            WebkitTransform: 'translate3d(' + _x + 'px, ' + y + 'px, 0) scaleX(' + scaleX + ') scaleY(' + scaleY + ')',
+                            transform: 'translate3d(' + _x + 'px, ' + _y + 'px, 0) scaleX(' + scaleX + ') scaleY(' + scaleY + ')',
+                            WebkitTransform: 'translate3d(' + _x + 'px, ' + _y + 'px, 0) scaleX(' + scaleX + ') scaleY(' + scaleY + ')',
                             position: 'absolute'
                         })
                     }));
@@ -22522,7 +22523,8 @@ MenuItem.propTypes = {
     bumpy: _react.PropTypes.bool.isRequired,
     speedOpen: _react.PropTypes.number,
     openSpeed: _react.PropTypes.number,
-    reverse: _react.PropTypes.bool
+    reverse: _react.PropTypes.bool,
+    type: _react.PropTypes.oneOf(['horizontal', 'vertical', 'circle']).isRequired
 };
 MenuItem.defaultProps = {
     onOpenAnimationEnd: function onOpenAnimationEnd() {},

--- a/docs/src/example.js
+++ b/docs/src/example.js
@@ -3,13 +3,13 @@ import MotionMenu from '../../src';
 
 export default () => (
     <MotionMenu
-        type="circle"
+        type="vertical"
         margin={120}
         y={0}
-        distFactor={0.5}
         bumpy={false}
         x={0}
         openSpeed={60}
+        wing={true}
         reverse={true}
     >
         <div className="button"><i className="fa fa-bars" /></div>

--- a/docs/src/example.js
+++ b/docs/src/example.js
@@ -3,14 +3,14 @@ import MotionMenu from '../../src';
 
 export default () => (
   <MotionMenu
-    type="horizontal"
+    type="vertical"
     margin={120}
     y={0}
     bumpy={false}
     x={0}
     openSpeed={10}
     wing={false}
-    reverse
+    reverse={false}
   >
     <div className="button"><i className="fa fa-bars" /></div>
     <div className="button"><i className="fa fa-cogs" /></div>

--- a/docs/src/example.js
+++ b/docs/src/example.js
@@ -10,7 +10,7 @@ export default () => (
         bumpy={false}
         x={0}
         openSpeed={60}
-        rightToLeft={true}
+        reverse={true}
     >
         <div className="button"><i className="fa fa-bars" /></div>
         <div className="button"><i className="fa fa-cogs" /></div>

--- a/docs/src/example.js
+++ b/docs/src/example.js
@@ -3,7 +3,7 @@ import MotionMenu from '../../src';
 
 export default () => (
     <MotionMenu
-        type="horizontal"
+        type="circle"
         margin={120}
         y={0}
         distFactor={0.5}

--- a/docs/src/example.js
+++ b/docs/src/example.js
@@ -2,23 +2,23 @@ import React from 'react';
 import MotionMenu from '../../src';
 
 export default () => (
-    <MotionMenu
-        type="vertical"
-        margin={120}
-        y={0}
-        bumpy={false}
-        x={0}
-        openSpeed={60}
-        wing={true}
-        reverse={true}
-    >
-        <div className="button"><i className="fa fa-bars" /></div>
-        <div className="button"><i className="fa fa-cogs" /></div>
-        <div className="button"><i className="fa fa-cloud" /></div>
-        <div className="button"><i className="fa fa-home" /></div>
-        <div className="button"><i className="fa fa-flash" /></div>
-        <div className="button"><i className="fa fa-heart" /></div>
-        <div className="button"><i className="fa fa-globe" /></div>
-        <div className="button"><i className="fa fa-plug" /></div>
-    </MotionMenu>
+  <MotionMenu
+    type="horizontal"
+    margin={120}
+    y={0}
+    bumpy={false}
+    x={0}
+    openSpeed={10}
+    wing={false}
+    reverse
+  >
+    <div className="button"><i className="fa fa-bars" /></div>
+    <div className="button"><i className="fa fa-cogs" /></div>
+    <div className="button"><i className="fa fa-cloud" /></div>
+    <div className="button"><i className="fa fa-home" /></div>
+    <div className="button"><i className="fa fa-flash" /></div>
+    <div className="button"><i className="fa fa-heart" /></div>
+    <div className="button"><i className="fa fa-globe" /></div>
+    <div className="button"><i className="fa fa-plug" /></div>
+  </MotionMenu>
 );

--- a/docs/src/example.js
+++ b/docs/src/example.js
@@ -7,9 +7,10 @@ export default () => (
         margin={120}
         y={0}
         distFactor={0.5}
-        bumpy={true}
+        bumpy={false}
         x={0}
         openSpeed={60}
+        rightToLeft={true}
     >
         <div className="button"><i className="fa fa-bars" /></div>
         <div className="button"><i className="fa fa-cogs" /></div>

--- a/docs/src/example.js
+++ b/docs/src/example.js
@@ -2,19 +2,22 @@ import React from 'react';
 import MotionMenu from '../../src';
 
 export default () => (
-  <MotionMenu
-    type="circle"
-    margin={120}
-    y={0}
-    x={0}
-  >
-    <div className="button"><i className="fa fa-bars" /></div>
-    <div className="button"><i className="fa fa-cogs" /></div>
-    <div className="button"><i className="fa fa-cloud" /></div>
-    <div className="button"><i className="fa fa-home" /></div>
-    <div className="button"><i className="fa fa-flash" /></div>
-    <div className="button"><i className="fa fa-heart" /></div>
-    <div className="button"><i className="fa fa-globe" /></div>
-    <div className="button"><i className="fa fa-plug" /></div>
-  </MotionMenu>
+    <MotionMenu
+        type="horizontal"
+        margin={120}
+        y={0}
+        distFactor={0.5}
+        bumpy={true}
+        x={0}
+        openSpeed={60}
+    >
+        <div className="button"><i className="fa fa-bars" /></div>
+        <div className="button"><i className="fa fa-cogs" /></div>
+        <div className="button"><i className="fa fa-cloud" /></div>
+        <div className="button"><i className="fa fa-home" /></div>
+        <div className="button"><i className="fa fa-flash" /></div>
+        <div className="button"><i className="fa fa-heart" /></div>
+        <div className="button"><i className="fa fa-globe" /></div>
+        <div className="button"><i className="fa fa-plug" /></div>
+    </MotionMenu>
 );

--- a/docs/src/example.js
+++ b/docs/src/example.js
@@ -3,12 +3,12 @@ import MotionMenu from '../../src';
 
 export default () => (
   <MotionMenu
-    type="vertical"
+    type="circle"
     margin={120}
     y={0}
-    bumpy={false}
+    bumpy
     x={0}
-    openSpeed={10}
+    openSpeed={60}
     wing={false}
     reverse={false}
   >

--- a/src/button.js
+++ b/src/button.js
@@ -20,12 +20,10 @@ export default class MenuButton extends Component {
       {
         scaleX: spring(1, { stiffness: 1500, damping: 10 }),
         scaleY: spring(1, { stiffness: 1500, damping: 10 }),
-      },
-      {
+      }, {
         scaleX: spring(0.6, { stiffness: 1500, damping: 50 }),
         scaleY: spring(0.6, { stiffness: 1500, damping: 50 }),
-      },
-      {
+      }, {
         scaleX: spring(1, { stiffness: 1500, damping: 10 }),
         scaleY: spring(1, { stiffness: 1500, damping: 10 }),
       },
@@ -34,12 +32,10 @@ export default class MenuButton extends Component {
       {
         scaleX: spring(1, { stiffness: 1500, damping: 10 }),
         scaleY: spring(1, { stiffness: 1500, damping: 10 }),
-      },
-      {
+      }, {
         scaleX: spring(1, { stiffness: 200, damping: 50 }),
         scaleY: spring(1, { stiffness: 200, damping: 50 }),
-      },
-      {
+      }, {
         scaleX: spring(1, { stiffness: 1500, damping: 10 }),
         scaleY: spring(1, { stiffness: 1500, damping: 10 }),
       },

--- a/src/button.js
+++ b/src/button.js
@@ -7,6 +7,7 @@ export default class MenuButton extends Component {
     x: PropTypes.number.isRequired,
     y: PropTypes.number.isRequired,
     onClick: PropTypes.func,
+      bumpy: PropTypes.bool
   };
 
   constructor(props) {
@@ -14,18 +15,36 @@ export default class MenuButton extends Component {
     this.state = {
       sequence: 0,
     };
-    this.sequenceParams = [
-      {
-        scaleX: spring(1, { stiffness: 1500, damping: 10 }),
-        scaleY: spring(1, { stiffness: 1500, damping: 10 }),
-      }, {
-        scaleX: spring(0.6, { stiffness: 1500, damping: 50 }),
-        scaleY: spring(0.6, { stiffness: 1500, damping: 50 }),
-      }, {
-        scaleX: spring(1, { stiffness: 1500, damping: 10 }),
-        scaleY: spring(1, { stiffness: 1500, damping: 10 }),
-      },
-    ];
+      this.sequenceParams = this.props.bumpy ?
+          [
+              {
+                  scaleX: spring(1, { stiffness: 1500, damping: 10 }),
+                  scaleY: spring(1, { stiffness: 1500, damping: 10 }),
+              },
+              {
+                  scaleX: spring(0.6, { stiffness: 1500, damping: 50 }),
+                  scaleY: spring(0.6, { stiffness: 1500, damping: 50 }),
+              },
+              {
+                  scaleX: spring(1, {stiffness: 1500, damping: 10}),
+                  scaleY: spring(1, {stiffness: 1500, damping: 10}),
+              }
+          ]:
+          [
+              {
+                  scaleX: spring(1, { stiffness: 1500, damping: 10 }),
+                  scaleY: spring(1, { stiffness: 1500, damping: 10 }),
+              },
+              {
+                  scaleX: spring(1, { stiffness: 200, damping: 50 }),
+                  scaleY: spring(1, { stiffness: 200, damping: 50 }),
+              },
+              {
+                  scaleX: spring(1, { stiffness: 1500, damping: 10 }),
+                  scaleY: spring(1, { stiffness: 1500, damping: 10 }),
+              },
+          ];
+
   }
 
   start() {

--- a/src/button.js
+++ b/src/button.js
@@ -7,7 +7,7 @@ export default class MenuButton extends Component {
     x: PropTypes.number.isRequired,
     y: PropTypes.number.isRequired,
     onClick: PropTypes.func,
-      bumpy: PropTypes.bool
+    bumpy: PropTypes.bool,
   };
 
   constructor(props) {
@@ -15,36 +15,35 @@ export default class MenuButton extends Component {
     this.state = {
       sequence: 0,
     };
-      this.sequenceParams = this.props.bumpy ?
-          [
-              {
+    this.sequenceParams = this.props.bumpy ?
+        [
+            {
                   scaleX: spring(1, { stiffness: 1500, damping: 10 }),
                   scaleY: spring(1, { stiffness: 1500, damping: 10 }),
-              },
-              {
+            },
+            {
                   scaleX: spring(0.6, { stiffness: 1500, damping: 50 }),
                   scaleY: spring(0.6, { stiffness: 1500, damping: 50 }),
-              },
-              {
+            },
+            {
                   scaleX: spring(1, {stiffness: 1500, damping: 10}),
                   scaleY: spring(1, {stiffness: 1500, damping: 10}),
-              }
-          ]:
-          [
-              {
+            }
+        ]:
+        [
+            {
                   scaleX: spring(1, { stiffness: 1500, damping: 10 }),
                   scaleY: spring(1, { stiffness: 1500, damping: 10 }),
-              },
-              {
+            },
+            {
                   scaleX: spring(1, { stiffness: 200, damping: 50 }),
                   scaleY: spring(1, { stiffness: 200, damping: 50 }),
-              },
-              {
+            },
+            {
                   scaleX: spring(1, { stiffness: 1500, damping: 10 }),
                   scaleY: spring(1, { stiffness: 1500, damping: 10 }),
-              },
-          ];
-
+            },
+        ];
   }
 
   start() {

--- a/src/button.js
+++ b/src/button.js
@@ -16,34 +16,34 @@ export default class MenuButton extends Component {
       sequence: 0,
     };
     this.sequenceParams = this.props.bumpy ?
-        [
-            {
-                  scaleX: spring(1, { stiffness: 1500, damping: 10 }),
-                  scaleY: spring(1, { stiffness: 1500, damping: 10 }),
-            },
-            {
-                  scaleX: spring(0.6, { stiffness: 1500, damping: 50 }),
-                  scaleY: spring(0.6, { stiffness: 1500, damping: 50 }),
-            },
-            {
-                  scaleX: spring(1, {stiffness: 1500, damping: 10}),
-                  scaleY: spring(1, {stiffness: 1500, damping: 10}),
-            }
-        ]:
-        [
-            {
-                  scaleX: spring(1, { stiffness: 1500, damping: 10 }),
-                  scaleY: spring(1, { stiffness: 1500, damping: 10 }),
-            },
-            {
-                  scaleX: spring(1, { stiffness: 200, damping: 50 }),
-                  scaleY: spring(1, { stiffness: 200, damping: 50 }),
-            },
-            {
-                  scaleX: spring(1, { stiffness: 1500, damping: 10 }),
-                  scaleY: spring(1, { stiffness: 1500, damping: 10 }),
-            },
-        ];
+    [
+      {
+        scaleX: spring(1, { stiffness: 1500, damping: 10 }),
+        scaleY: spring(1, { stiffness: 1500, damping: 10 }),
+      },
+      {
+        scaleX: spring(0.6, { stiffness: 1500, damping: 50 }),
+        scaleY: spring(0.6, { stiffness: 1500, damping: 50 }),
+      },
+      {
+        scaleX: spring(1, { stiffness: 1500, damping: 10 }),
+        scaleY: spring(1, { stiffness: 1500, damping: 10 }),
+      },
+    ] :
+    [
+      {
+        scaleX: spring(1, { stiffness: 1500, damping: 10 }),
+        scaleY: spring(1, { stiffness: 1500, damping: 10 }),
+      },
+      {
+        scaleX: spring(1, { stiffness: 200, damping: 50 }),
+        scaleY: spring(1, { stiffness: 200, damping: 50 }),
+      },
+      {
+        scaleX: spring(1, { stiffness: 1500, damping: 10 }),
+        scaleY: spring(1, { stiffness: 1500, damping: 10 }),
+      },
+    ];
   }
 
   start() {

--- a/src/index.js
+++ b/src/index.js
@@ -15,7 +15,8 @@ export default class MotionMenu extends Component {
         className: PropTypes.string,
         bumpy: PropTypes.bool,
         distFactor: PropTypes.number,
-        openSpeed: PropTypes.number
+        openSpeed: PropTypes.number,
+        rightToLeft: PropTypes.bool
     }
 
     static defaultProps = {
@@ -26,7 +27,8 @@ export default class MotionMenu extends Component {
         onOpen: () => {},
         bumpy: false,
         distFactor: 0.5,
-        openSpeed: 60
+        openSpeed: 60,
+        rightToLeft: false
     }
 
     constructor(props) {
@@ -119,6 +121,7 @@ export default class MotionMenu extends Component {
                         y={this.getY(i, y)}
                         bumpy={bumpy}
                         openSpeed={this.props.openSpeed}
+                        rightToLeft={this.props.rightToLeft}
                     >
                         {this.props.children[i + 1]}
                     </MenuItem>

--- a/src/index.js
+++ b/src/index.js
@@ -16,7 +16,7 @@ export default class MotionMenu extends Component {
         bumpy: PropTypes.bool,
         distFactor: PropTypes.number,
         openSpeed: PropTypes.number,
-        rightToLeft: PropTypes.bool
+        reverse: PropTypes.bool
     }
 
     static defaultProps = {
@@ -28,7 +28,7 @@ export default class MotionMenu extends Component {
         bumpy: false,
         distFactor: 0.5,
         openSpeed: 60,
-        rightToLeft: false
+        reverse: false
     }
 
     constructor(props) {
@@ -121,7 +121,7 @@ export default class MotionMenu extends Component {
                         y={this.getY(i, y)}
                         bumpy={bumpy}
                         openSpeed={this.props.openSpeed}
-                        rightToLeft={this.props.rightToLeft}
+                        reverse={this.props.reverse}
                     >
                         {this.props.children[i + 1]}
                     </MenuItem>

--- a/src/index.js
+++ b/src/index.js
@@ -111,7 +111,6 @@ export default class MotionMenu extends Component {
             .reverse()
             .map(i => (
                     <MenuItem
-                        direction={this.props.type}
                         key={i}
                         ref={(c) => { this.items[i + 1] = c; }}
                         name={`item${i + 1}`}
@@ -122,6 +121,7 @@ export default class MotionMenu extends Component {
                         bumpy={bumpy}
                         openSpeed={this.props.openSpeed}
                         reverse={this.props.reverse}
+                        type={this.props.type}
                     >
                         {this.props.children[i + 1]}
                     </MenuItem>

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ export default class MotionMenu extends Component {
     style: {},
     onClose: () => {},
     onOpen: () => {},
-    bumpy: false,
+    bumpy: true,
     openSpeed: 60,
     reverse: false,
   }

--- a/src/index.js
+++ b/src/index.js
@@ -4,168 +4,177 @@ import MenuButton from './button';
 
 export default class MotionMenu extends Component {
 
-  static propTypes = {
-    margin: PropTypes.number.isRequired,
-    type: PropTypes.oneOf(['horizontal', 'vertical', 'circle']).isRequired,
-    wing: PropTypes.bool,
-    x: PropTypes.number,
-    y: PropTypes.number,
-    onClose: PropTypes.func,
-    onOpen: PropTypes.func,
-    className: PropTypes.string,
-  }
-
-  static defaultProps = {
-    x: 0,
-    y: 0,
-    style: {},
-    onClose: () => {},
-    onOpen: () => {},
-  }
-
-  constructor(props) {
-    super(props);
-    this.state = {
-      itemNumber: 1,
-      status: 'idle',
-    };
-    this.items = [];
-    this.onOpenEnd = this.onOpenEnd.bind(this);
-    this.onCloseEnd = this.onCloseEnd.bind(this);
-    this.onClick = this.onClick.bind(this);
-  }
-
-  onOpenEnd(name) {
-    if (this.state.action !== 'open') return;
-    if (this.state.itemNumber < this.props.children.length) {
-      this.items[this.state.itemNumber].start();
-      this.setState({
-        itemNumber: this.state.itemNumber + 1,
-      });
-      return;
+    static propTypes = {
+        margin: PropTypes.number.isRequired,
+        type: PropTypes.oneOf(['horizontal', 'vertical', 'circle']).isRequired,
+        wing: PropTypes.bool,
+        x: PropTypes.number,
+        y: PropTypes.number,
+        onClose: PropTypes.func,
+        onOpen: PropTypes.func,
+        className: PropTypes.string,
+        bumpy: PropTypes.bool,
+        distFactor: PropTypes.number,
+        openSpeed: PropTypes.number
     }
-    if (name === `item${this.props.children.length - 1}`) {
-      this.props.onOpen();
+
+    static defaultProps = {
+        x: 0,
+        y: 0,
+        style: {},
+        onClose: () => {},
+        onOpen: () => {},
+        bumpy: false,
+        distFactor: 0.5,
+        openSpeed: 60
     }
-  }
 
-  onCloseEnd(name) {
-    if (this.state.action === 'open') return;
-    if (this.state.itemNumber > 1) {
-      if (name === 'item1') {
-        this.props.onClose();
-      }
-      this.setState({
-        itemNumber: this.state.itemNumber - 1,
-      });
+    constructor(props) {
+        super(props);
+        this.state = {
+            itemNumber: 1,
+            status: 'idle',
+        };
+        this.items = [];
+        this.onOpenEnd = this.onOpenEnd.bind(this);
+        this.onCloseEnd = this.onCloseEnd.bind(this);
+        this.onClick = this.onClick.bind(this);
     }
-  }
 
-  onClick() {
-    if (this.state.action === 'open') {
-      this.closeItems();
-    } else {
-      this.openItem();
+    onOpenEnd(name) {
+        if (this.state.action !== 'open') return;
+        if (this.state.itemNumber < this.props.children.length) {
+            this.items[this.state.itemNumber].start();
+            this.setState({
+                itemNumber: this.state.itemNumber + 1,
+            });
+            return;
+        }
+        if (name === `item${this.props.children.length - 1}`) {
+            this.props.onOpen();
+        }
     }
-  }
 
-  getDistance(i) {
-    return this.props.wing
-      ? (parseInt(i / 2, 10) + 1) * this.props.margin * ((i % 2) || -1)
-      : this.props.margin * (i + 1);
-  }
-
-  getX(i, x) {
-    const { type, margin, children } = this.props;
-    if (type === 'horizontal') {
-      return this.getDistance(i) + x;
+    onCloseEnd(name) {
+        if (this.state.action === 'open') return;
+        if (this.state.itemNumber > 1) {
+            if (name === 'item1') {
+                this.props.onClose();
+            }
+            this.setState({
+                itemNumber: this.state.itemNumber - 1,
+            });
+        }
     }
-    if (type === 'circle') {
-      return x + (margin * Math.cos((Math.PI * 2 * i) / (children.length - 1)));
+
+    onClick() {
+        if (this.state.action === 'open') {
+            this.closeItems();
+        } else {
+            this.openItem();
+        }
     }
-    return x;
-  }
 
-  getY(i, y) {
-    const { type, margin, children } = this.props;
-    if (type === 'vertical') {
-      return this.getDistance(i) + y;
+    getDistance(i) {
+        return this.props.wing
+            ? (parseInt(i / 2, 10) + 1) * this.props.margin * ((i % 2) || -1)
+            : this.props.margin * (i + 1) * (this.props.distFactor);
     }
-    if (type === 'circle') {
-      return y + (margin * Math.sin((Math.PI * 2 * i) / (children.length - 1)));
+
+    getX(i, x) {
+        const { type, margin, children } = this.props;
+        if (type === 'horizontal') {
+            return this.getDistance(i) + x;
+        }
+        if (type === 'circle') {
+            return x + (margin * Math.cos((Math.PI * 2 * i) / (children.length - 1)));
+        }
+        return x;
     }
-    return y;
-  }
 
-  getItems() {
-    const { x, y } = this.props;
-    return Array.from(Array(this.state.itemNumber).keys())
-      .reverse()
-      .map(i => (
-        <MenuItem
-          direction={this.props.type}
-          key={i}
-          ref={(c) => { this.items[i + 1] = c; }}
-          name={`item${i + 1}`}
-          onOpenAnimationEnd={this.onOpenEnd}
-          onCloseAnimationEnd={this.onCloseEnd}
-          x={this.getX(i, x)}
-          y={this.getY(i, y)}
-        >
-          {this.props.children[i + 1]}
-        </MenuItem>
-      ),
-    );
-  }
+    getY(i, y) {
+        const { type, margin, children } = this.props;
+        if (type === 'vertical') {
+            return this.getDistance(i) + y;
+        }
+        if (type === 'circle') {
+            return y + (margin * Math.sin((Math.PI * 2 * i) / (children.length - 1)));
+        }
+        return y;
+    }
 
-  get menuButton() {
-    return (
-      <MenuButton
-        ref={(c) => { this.button = c; }}
-        onClick={this.onClick}
-        x={this.props.x}
-        y={this.props.y}
-      >
-        {this.props.children[0]}
-      </MenuButton>
-    );
-  }
+    getItems() {
+        const { x, y, bumpy } = this.props;
+        return Array.from(Array(this.state.itemNumber).keys())
+            .reverse()
+            .map(i => (
+                    <MenuItem
+                        direction={this.props.type}
+                        key={i}
+                        ref={(c) => { this.items[i + 1] = c; }}
+                        name={`item${i + 1}`}
+                        onOpenAnimationEnd={this.onOpenEnd}
+                        onCloseAnimationEnd={this.onCloseEnd}
+                        x={this.getX(i, x)}
+                        y={this.getY(i, y)}
+                        bumpy={bumpy}
+                        openSpeed={this.props.openSpeed}
+                    >
+                        {this.props.children[i + 1]}
+                    </MenuItem>
+                ),
+            );
+    }
 
-  closeItems() {
-    this.setState({ action: 'close' });
-    this.button.reverse();
-    Array.from(Array(this.state.itemNumber).keys())
-      .reverse()
-      .forEach(i => this.items[i + 1].reverse());
-  }
+    get menuButton() {
+        return (
+            <MenuButton
+                ref={(c) => { this.button = c; }}
+                onClick={this.onClick}
+                x={this.props.x}
+                y={this.props.y}
+                bumpy={this.props.bumpy}
+            >
+                {this.props.children[0]}
+            </MenuButton>
+        );
+    }
 
-  close() {
-    if (this.state.action !== 'open') return;
-    this.closeItems();
-  }
+    closeItems() {
+        this.setState({ action: 'close' });
+        this.button.reverse();
+        Array.from(Array(this.state.itemNumber).keys())
+            .reverse()
+            .forEach(i => this.items[i + 1].reverse());
+    }
 
-  open() {
-    if (this.state.action === 'open') return;
-    this.openItem();
-  }
+    close() {
+        if (this.state.action !== 'open') return;
+        this.closeItems();
+    }
 
-  openItem() {
-    this.setState({ action: 'open' });
-    this.button.start();
-    this.items[this.state.itemNumber].start();
-  }
+    open() {
+        if (this.state.action === 'open') return;
+        this.openItem();
+    }
 
-  render() {
-    return (
-      <div
-        style={this.props.style}
-        className={this.props.className}
-      >
-        <div style={{ position: 'relative' }}>
-          {this.menuButton}
-          {this.getItems()}
-        </div>
-      </div>
-    );
-  }
+    openItem() {
+        this.setState({ action: 'open' });
+        this.button.start();
+        this.items[this.state.itemNumber].start();
+    }
+
+    render() {
+        return (
+            <div
+                style={this.props.style}
+                className={this.props.className}
+            >
+                <div style={{ position: 'relative' }}>
+                    {this.menuButton}
+                    {this.getItems()}
+                </div>
+            </div>
+        );
+    }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -77,8 +77,8 @@ export default class MotionMenu extends Component {
 
   getDistance(i) {
     return this.props.wing
-            ? (parseInt(i / 2, 10) + 1) * this.props.margin * ((i % 2) || -1)
-            : this.props.margin * (i + 1);
+      ? (parseInt(i / 2, 10) + 1) * this.props.margin * ((i % 2) || -1)
+      : this.props.margin * (i + 1);
   }
 
   getX(i, x) {
@@ -123,8 +123,8 @@ export default class MotionMenu extends Component {
         >
           {this.props.children[i + 1]}
         </MenuItem>
-                ),
-            );
+      ),
+    );
   }
 
   get menuButton() {

--- a/src/index.js
+++ b/src/index.js
@@ -106,23 +106,23 @@ export default class MotionMenu extends Component {
   getItems() {
     const { x, y, bumpy } = this.props;
     return Array.from(Array(this.state.itemNumber).keys())
-            .reverse()
-            .map(i => (
-              <MenuItem
-                key={i}
-                ref={(c) => { this.items[i + 1] = c; }}
-                name={`item${i + 1}`}
-                onOpenAnimationEnd={this.onOpenEnd}
-                onCloseAnimationEnd={this.onCloseEnd}
-                x={this.getX(i, x)}
-                y={this.getY(i, y)}
-                bumpy={bumpy}
-                openSpeed={this.props.openSpeed}
-                reverse={this.props.reverse}
-                type={this.props.type}
-              >
-                {this.props.children[i + 1]}
-              </MenuItem>
+      .reverse()
+      .map(i => (
+        <MenuItem
+          key={i}
+          ref={(c) => { this.items[i + 1] = c; }}
+          name={`item${i + 1}`}
+          onOpenAnimationEnd={this.onOpenEnd}
+          onCloseAnimationEnd={this.onCloseEnd}
+          x={this.getX(i, x)}
+          y={this.getY(i, y)}
+          bumpy={bumpy}
+          openSpeed={this.props.openSpeed}
+          reverse={this.props.reverse}
+          type={this.props.type}
+        >
+          {this.props.children[i + 1]}
+        </MenuItem>
                 ),
             );
   }
@@ -145,8 +145,8 @@ export default class MotionMenu extends Component {
     this.setState({ action: 'close' });
     this.button.reverse();
     Array.from(Array(this.state.itemNumber).keys())
-            .reverse()
-            .forEach(i => this.items[i + 1].reverse());
+      .reverse()
+      .forEach(i => this.items[i + 1].reverse());
   }
 
   close() {

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,6 @@ export default class MotionMenu extends Component {
         onOpen: PropTypes.func,
         className: PropTypes.string,
         bumpy: PropTypes.bool,
-        distFactor: PropTypes.number,
         openSpeed: PropTypes.number,
         reverse: PropTypes.bool
     }
@@ -26,7 +25,6 @@ export default class MotionMenu extends Component {
         onClose: () => {},
         onOpen: () => {},
         bumpy: false,
-        distFactor: 0.5,
         openSpeed: 60,
         reverse: false
     }
@@ -80,7 +78,7 @@ export default class MotionMenu extends Component {
     getDistance(i) {
         return this.props.wing
             ? (parseInt(i / 2, 10) + 1) * this.props.margin * ((i % 2) || -1)
-            : this.props.margin * (i + 1) * (this.props.distFactor);
+            : this.props.margin * (i + 1);
     }
 
     getX(i, x) {

--- a/src/index.js
+++ b/src/index.js
@@ -4,178 +4,178 @@ import MenuButton from './button';
 
 export default class MotionMenu extends Component {
 
-    static propTypes = {
-        margin: PropTypes.number.isRequired,
-        type: PropTypes.oneOf(['horizontal', 'vertical', 'circle']).isRequired,
-        wing: PropTypes.bool,
-        x: PropTypes.number,
-        y: PropTypes.number,
-        onClose: PropTypes.func,
-        onOpen: PropTypes.func,
-        className: PropTypes.string,
-        bumpy: PropTypes.bool,
-        openSpeed: PropTypes.number,
-        reverse: PropTypes.bool
-    }
+  static propTypes = {
+    margin: PropTypes.number.isRequired,
+    type: PropTypes.oneOf(['horizontal', 'vertical', 'circle']).isRequired,
+    wing: PropTypes.bool,
+    x: PropTypes.number,
+    y: PropTypes.number,
+    onClose: PropTypes.func,
+    onOpen: PropTypes.func,
+    className: PropTypes.string,
+    bumpy: PropTypes.bool,
+    openSpeed: PropTypes.number,
+    reverse: PropTypes.bool,
+  }
 
-    static defaultProps = {
-        x: 0,
-        y: 0,
-        style: {},
-        onClose: () => {},
-        onOpen: () => {},
-        bumpy: false,
-        openSpeed: 60,
-        reverse: false
-    }
+  static defaultProps = {
+    x: 0,
+    y: 0,
+    style: {},
+    onClose: () => {},
+    onOpen: () => {},
+    bumpy: false,
+    openSpeed: 60,
+    reverse: false,
+  }
 
-    constructor(props) {
-        super(props);
-        this.state = {
-            itemNumber: 1,
-            status: 'idle',
-        };
-        this.items = [];
-        this.onOpenEnd = this.onOpenEnd.bind(this);
-        this.onCloseEnd = this.onCloseEnd.bind(this);
-        this.onClick = this.onClick.bind(this);
-    }
+  constructor(props) {
+    super(props);
+    this.state = {
+      itemNumber: 1,
+      status: 'idle',
+    };
+    this.items = [];
+    this.onOpenEnd = this.onOpenEnd.bind(this);
+    this.onCloseEnd = this.onCloseEnd.bind(this);
+    this.onClick = this.onClick.bind(this);
+  }
 
-    onOpenEnd(name) {
-        if (this.state.action !== 'open') return;
-        if (this.state.itemNumber < this.props.children.length) {
-            this.items[this.state.itemNumber].start();
-            this.setState({
-                itemNumber: this.state.itemNumber + 1,
-            });
-            return;
-        }
-        if (name === `item${this.props.children.length - 1}`) {
-            this.props.onOpen();
-        }
+  onOpenEnd(name) {
+    if (this.state.action !== 'open') return;
+    if (this.state.itemNumber < this.props.children.length) {
+      this.items[this.state.itemNumber].start();
+      this.setState({
+        itemNumber: this.state.itemNumber + 1,
+      });
+      return;
     }
-
-    onCloseEnd(name) {
-        if (this.state.action === 'open') return;
-        if (this.state.itemNumber > 1) {
-            if (name === 'item1') {
-                this.props.onClose();
-            }
-            this.setState({
-                itemNumber: this.state.itemNumber - 1,
-            });
-        }
+    if (name === `item${this.props.children.length - 1}`) {
+      this.props.onOpen();
     }
+  }
 
-    onClick() {
-        if (this.state.action === 'open') {
-            this.closeItems();
-        } else {
-            this.openItem();
-        }
+  onCloseEnd(name) {
+    if (this.state.action === 'open') return;
+    if (this.state.itemNumber > 1) {
+      if (name === 'item1') {
+        this.props.onClose();
+      }
+      this.setState({
+        itemNumber: this.state.itemNumber - 1,
+      });
     }
+  }
 
-    getDistance(i) {
-        return this.props.wing
+  onClick() {
+    if (this.state.action === 'open') {
+      this.closeItems();
+    } else {
+      this.openItem();
+    }
+  }
+
+  getDistance(i) {
+    return this.props.wing
             ? (parseInt(i / 2, 10) + 1) * this.props.margin * ((i % 2) || -1)
             : this.props.margin * (i + 1);
-    }
+  }
 
-    getX(i, x) {
-        const { type, margin, children } = this.props;
-        if (type === 'horizontal') {
-            return this.getDistance(i) + x;
-        }
-        if (type === 'circle') {
-            return x + (margin * Math.cos((Math.PI * 2 * i) / (children.length - 1)));
-        }
-        return x;
+  getX(i, x) {
+    const { type, margin, children } = this.props;
+    if (type === 'horizontal') {
+      return this.getDistance(i) + x;
     }
-
-    getY(i, y) {
-        const { type, margin, children } = this.props;
-        if (type === 'vertical') {
-            return this.getDistance(i) + y;
-        }
-        if (type === 'circle') {
-            return y + (margin * Math.sin((Math.PI * 2 * i) / (children.length - 1)));
-        }
-        return y;
+    if (type === 'circle') {
+      return x + (margin * Math.cos((Math.PI * 2 * i) / (children.length - 1)));
     }
+    return x;
+  }
 
-    getItems() {
-        const { x, y, bumpy } = this.props;
-        return Array.from(Array(this.state.itemNumber).keys())
+  getY(i, y) {
+    const { type, margin, children } = this.props;
+    if (type === 'vertical') {
+      return this.getDistance(i) + y;
+    }
+    if (type === 'circle') {
+      return y + (margin * Math.sin((Math.PI * 2 * i) / (children.length - 1)));
+    }
+    return y;
+  }
+
+  getItems() {
+    const { x, y, bumpy } = this.props;
+    return Array.from(Array(this.state.itemNumber).keys())
             .reverse()
             .map(i => (
-                    <MenuItem
-                        key={i}
-                        ref={(c) => { this.items[i + 1] = c; }}
-                        name={`item${i + 1}`}
-                        onOpenAnimationEnd={this.onOpenEnd}
-                        onCloseAnimationEnd={this.onCloseEnd}
-                        x={this.getX(i, x)}
-                        y={this.getY(i, y)}
-                        bumpy={bumpy}
-                        openSpeed={this.props.openSpeed}
-                        reverse={this.props.reverse}
-                        type={this.props.type}
-                    >
-                        {this.props.children[i + 1]}
-                    </MenuItem>
+              <MenuItem
+                key={i}
+                ref={(c) => { this.items[i + 1] = c; }}
+                name={`item${i + 1}`}
+                onOpenAnimationEnd={this.onOpenEnd}
+                onCloseAnimationEnd={this.onCloseEnd}
+                x={this.getX(i, x)}
+                y={this.getY(i, y)}
+                bumpy={bumpy}
+                openSpeed={this.props.openSpeed}
+                reverse={this.props.reverse}
+                type={this.props.type}
+              >
+                {this.props.children[i + 1]}
+              </MenuItem>
                 ),
             );
-    }
+  }
 
-    get menuButton() {
-        return (
-            <MenuButton
-                ref={(c) => { this.button = c; }}
-                onClick={this.onClick}
-                x={this.props.x}
-                y={this.props.y}
-                bumpy={this.props.bumpy}
-            >
-                {this.props.children[0]}
-            </MenuButton>
-        );
-    }
+  get menuButton() {
+    return (
+      <MenuButton
+        ref={(c) => { this.button = c; }}
+        onClick={this.onClick}
+        x={this.props.x}
+        y={this.props.y}
+        bumpy={this.props.bumpy}
+      >
+        {this.props.children[0]}
+      </MenuButton>
+    );
+  }
 
-    closeItems() {
-        this.setState({ action: 'close' });
-        this.button.reverse();
-        Array.from(Array(this.state.itemNumber).keys())
+  closeItems() {
+    this.setState({ action: 'close' });
+    this.button.reverse();
+    Array.from(Array(this.state.itemNumber).keys())
             .reverse()
             .forEach(i => this.items[i + 1].reverse());
-    }
+  }
 
-    close() {
-        if (this.state.action !== 'open') return;
-        this.closeItems();
-    }
+  close() {
+    if (this.state.action !== 'open') return;
+    this.closeItems();
+  }
 
-    open() {
-        if (this.state.action === 'open') return;
-        this.openItem();
-    }
+  open() {
+    if (this.state.action === 'open') return;
+    this.openItem();
+  }
 
-    openItem() {
-        this.setState({ action: 'open' });
-        this.button.start();
-        this.items[this.state.itemNumber].start();
-    }
+  openItem() {
+    this.setState({ action: 'open' });
+    this.button.start();
+    this.items[this.state.itemNumber].start();
+  }
 
-    render() {
-        return (
-            <div
-                style={this.props.style}
-                className={this.props.className}
-            >
-                <div style={{ position: 'relative' }}>
-                    {this.menuButton}
-                    {this.getItems()}
-                </div>
-            </div>
-        );
-    }
+  render() {
+    return (
+      <div
+        style={this.props.style}
+        className={this.props.className}
+      >
+        <div style={{ position: 'relative' }}>
+          {this.menuButton}
+          {this.getItems()}
+        </div>
+      </div>
+    );
+  }
 }

--- a/src/item.js
+++ b/src/item.js
@@ -51,7 +51,6 @@ export default class MenuItem extends Component {
     onOpenAnimationEnd: PropTypes.func,
     onCloseAnimationEnd: PropTypes.func,
     bumpy: PropTypes.bool.isRequired,
-    speedOpen: PropTypes.number,
     openSpeed: PropTypes.number,
     reverse: PropTypes.bool,
     type: PropTypes.oneOf(['horizontal', 'vertical', 'circle']).isRequired,
@@ -96,8 +95,15 @@ export default class MenuItem extends Component {
 
   render() {
     const { x, y, reverse, type } = this.props;
-    const _x = reverse ? (-1) * (x) : x;
-    const _y = (type === 'vertical' && reverse) ? (-1) * (y) : y;
+    let newX;
+    let newY;
+    if (reverse) {
+      newX = (-1) * (x);
+      newY = type === 'vertical' ? (-1) * (y) : y;
+    } else {
+      newX = x;
+      newY = y;
+    }
     if (!this.props.children) return null;
     return (
       <Motion style={this.sequenceParams[this.state.sequence]}>
@@ -108,8 +114,8 @@ export default class MenuItem extends Component {
               ...(this.props.children.props || {}),
               style: {
                 ...((this.props.children.props && this.props.children.props.style) || {}),
-                transform: `translate3d(${_x}px, ${_y}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`,
-                WebkitTransform: `translate3d(${_x}px, ${_y}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`,
+                transform: `translate3d(${newX}px, ${newY}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`,
+                WebkitTransform: `translate3d(${newX}px, ${newY}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`,
                 position: 'absolute',
               },
             },

--- a/src/item.js
+++ b/src/item.js
@@ -1,94 +1,119 @@
 import React, { Component, PropTypes, cloneElement } from 'react';
 import { Motion, spring } from 'react-motion';
 
-const createParams = ({ x, y }) => ([
-  {
-    scaleX: spring(0, { stiffness: 1500, damping: 100 }),
-    scaleY: spring(0, { stiffness: 1500, damping: 100 }),
-    x: spring(x, { stiffness: 1500, damping: 50 }),
-    y: spring(y, { stiffness: 1500, damping: 50 }),
-  },
-  {
-    scaleX: spring(1.6, { stiffness: 1500, damping: 150 }),
-    scaleY: spring(0.7, { stiffness: 1500, damping: 150 }),
-    x: spring(x, { stiffness: 1500, damping: 100 }),
-    y: spring(y, { stiffness: 1500, damping: 100 }),
-  },
-  {
-    scaleX: spring(1, { stiffness: 1500, damping: 18 }),
-    scaleY: spring(1, { stiffness: 1500, damping: 18 }),
-    x: spring(x, { stiffness: 1500, damping: 100 }),
-    y: spring(y, { stiffness: 1500, damping: 100 }),
-  },
+const createSmoothParams = ({ x, y }) => ([
+    {
+        scaleX: spring(0, { stiffness: 1500, damping: 100 }),
+        scaleY: spring(0, { stiffness: 1500, damping: 100 }),
+        x: spring(x, { stiffness: 1500, damping: 50 }),
+        y: spring(y, { stiffness: 1500, damping: 50 }),
+    },
+    {
+        scaleX: spring(0.5, { stiffness: 120, damping: 20 }),
+        scaleY: spring(0.5, { stiffness: 120, damping: 20 }),
+        x: spring(x, { stiffness: 120, damping: 20 }),
+        y: spring(y, { stiffness: 120, damping: 20 }),
+    },
+    {
+        scaleX: spring(1, { stiffness: 120, damping: 20 }),
+        scaleY: spring(1, { stiffness: 120, damping: 20 }),
+        x: spring(x, { stiffness: 120, damping: 20 }),
+        y: spring(y, { stiffness: 120, damping: 20 }),
+    },
 ]);
+
+const createBumpyParams = ({ x, y }) => ([
+        {
+            scaleX: spring(0, { stiffness: 1500, damping: 100 }),
+            scaleY: spring(0, { stiffness: 1500, damping: 100 }),
+            x: spring(x, { stiffness: 1500, damping: 50 }),
+            y: spring(y, { stiffness: 1500, damping: 50 }),
+        },
+        {
+            scaleX: spring(1.6, { stiffness: 1500, damping: 150 }),
+            scaleY: spring(0.7, { stiffness: 1500, damping: 150 }),
+            x: spring(x, { stiffness: 1500, damping: 100 }),
+            y: spring(y, { stiffness: 1500, damping: 100 }),
+        },
+        {
+            scaleX: spring(1, { stiffness: 1500, damping: 18 }),
+            scaleY: spring(1, { stiffness: 1500, damping: 18 }),
+            x: spring(x, { stiffness: 1500, damping: 100 }),
+            y: spring(y, { stiffness: 1500, damping: 100 }),
+        },
+]);
+
 
 export default class MenuItem extends Component {
 
-  static propTypes = {
-    x: PropTypes.number.isRequired,
-    y: PropTypes.number.isRequired,
-    name: PropTypes.string.isRequired,
-    onOpenAnimationEnd: PropTypes.func,
-    onCloseAnimationEnd: PropTypes.func,
-  }
+    static propTypes = {
+        x: PropTypes.number.isRequired,
+        y: PropTypes.number.isRequired,
+        name: PropTypes.string.isRequired,
+        onOpenAnimationEnd: PropTypes.func,
+        onCloseAnimationEnd: PropTypes.func,
+        bumpy: PropTypes.bool.isRequired,
+        speedOpen: PropTypes.number,
+        openSpeed: PropTypes.number
+    }
 
-  static defaultProps = {
-    onOpenAnimationEnd: () => {},
-    onCloseAnimationEnd: () => {},
-  }
+    static defaultProps = {
+        onOpenAnimationEnd: () => {},
+        onCloseAnimationEnd: () => {},
+    }
 
-  constructor(props) {
-    super(props);
-    this.timerIds = [];
-    this.state = {
-      sequence: 0,
-    };
-    this.sequenceParams = createParams(props);
-  }
+    constructor(props) {
+        super(props);
+        this.timerIds = [];
+        this.state = {
+            sequence: 0,
+        };
+        this.sequenceParams =  this.props.bumpy ? createBumpyParams(props) : createSmoothParams(props);
+    }
 
-  start() {
-    this.timerIds[1] = setTimeout(() => {
-      this.setState({ sequence: 1 });
-      this.timerIds[1] = null;
-    }, 60);
+    start() {
+        this.timerIds[1] = setTimeout(() => {
+            this.setState({ sequence: 1 });
+            this.timerIds[1] = null;
+        }, this.props.openSpeed);
 
-    this.timerIds[2] = setTimeout(() => {
-      this.setState({ sequence: 2 });
-      this.timerIds[2] = null;
-      this.props.onOpenAnimationEnd(this.props.name);
-    }, 80);
-  }
+        this.timerIds[2] = setTimeout(() => {
+            this.setState({ sequence: 2 });
+            this.timerIds[2] = null;
+            this.props.onOpenAnimationEnd(this.props.name);
+        }, this.props.openSpeed);
+    }
 
-  reverse() {
-    this.timerIds.forEach((id) => { if (id) clearTimeout(id); });
-    this.timerIds[0] = setTimeout(() => {
-      this.timerIds[0] = null;
-      this.props.onCloseAnimationEnd(this.props.name);
-    }, 100);
-    this.setState({ sequence: 0 });
-  }
+    reverse() {
+        this.timerIds.forEach((id) => { if (id) clearTimeout(id); });
+        this.timerIds[0] = setTimeout(() => {
+            this.timerIds[0] = null;
+            this.props.onCloseAnimationEnd(this.props.name);
+        }, 80);
+        this.setState({ sequence: 0 });
+    }
 
-  render() {
-    const { x, y } = this.props;
-    if (!this.props.children) return null;
-    return (
-      <Motion style={this.sequenceParams[this.state.sequence]}>
-        {({ scaleX, scaleY }) => (
-          cloneElement(
-            this.props.children,
-            {
-              ...(this.props.children.props || {}),
-              style: {
-                ...((this.props.children.props && this.props.children.props.style) || {}),
-                transform: `translate3d(${x}px, ${y}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`,
-                WebkitTransform: `translate3d(${x}px, ${y}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`,
-                position: 'absolute',
-              },
-            },
-          )
-        )
-      }
-      </Motion>
-    );
-  }
+    render() {
+        const { x, y } = this.props;
+        if (!this.props.children) return null;
+        return (
+            <Motion style={this.sequenceParams[this.state.sequence]}>
+                {({ scaleX, scaleY }) => (
+                    cloneElement(
+                        this.props.children,
+                        {
+                            ...(this.props.children.props || {}),
+                            style: {
+                                ...((this.props.children.props && this.props.children.props.style) || {}),
+                                transform: `translate3d(${x}px, ${y}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`,
+                                WebkitTransform: `translate3d(${x}px, ${y}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`,
+                                position: 'absolute',
+                            },
+                        },
+                    )
+                )
+                }
+            </Motion>
+        );
+    }
 }

--- a/src/item.js
+++ b/src/item.js
@@ -90,7 +90,7 @@ export default class MenuItem extends Component {
     this.timerIds[0] = setTimeout(() => {
       this.timerIds[0] = null;
       this.props.onCloseAnimationEnd(this.props.name);
-    }, 80);
+    }, 100);
     this.setState({ sequence: 0 });
   }
 
@@ -115,7 +115,7 @@ export default class MenuItem extends Component {
             },
           )
         )
-       }
+      }
       </Motion>
     );
   }

--- a/src/item.js
+++ b/src/item.js
@@ -55,7 +55,7 @@ export default class MenuItem extends Component {
         bumpy: PropTypes.bool.isRequired,
         speedOpen: PropTypes.number,
         openSpeed: PropTypes.number,
-        rightToLeft: PropTypes.bool
+        reverse: PropTypes.bool
     }
 
     static defaultProps = {
@@ -96,13 +96,8 @@ export default class MenuItem extends Component {
     }
 
     render() {
-        const { x, y, rightToLeft } = this.props;
-        let _X;
-        if (rightToLeft){
-            _X = (-1) * (x);
-        }else {
-            _X = x;
-        }
+        const { x, y, reverse } = this.props;
+        const _x = reverse ? (-1) * (x) : x;
 
         if (!this.props.children) return null;
         return (
@@ -114,8 +109,8 @@ export default class MenuItem extends Component {
                             ...(this.props.children.props || {}),
                             style: {
                                 ...((this.props.children.props && this.props.children.props.style) || {}),
-                                transform: `translate3d(${_X}px, ${y}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`,
-                                WebkitTransform: `translate3d(${_X}px, ${y}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`,
+                                transform: `translate3d(${_x}px, ${y}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`,
+                                WebkitTransform: `translate3d(${_x}px, ${y}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`,
                                 position: 'absolute',
                             },
                         },

--- a/src/item.js
+++ b/src/item.js
@@ -7,14 +7,12 @@ const createSmoothParams = ({ x, y }) => ([
     scaleY: spring(0, { stiffness: 1500, damping: 100 }),
     x: spring(x, { stiffness: 1500, damping: 50 }),
     y: spring(y, { stiffness: 1500, damping: 50 }),
-  },
-  {
+  }, {
     scaleX: spring(0.5, { stiffness: 120, damping: 20 }),
     scaleY: spring(0.5, { stiffness: 120, damping: 20 }),
     x: spring(x, { stiffness: 120, damping: 20 }),
     y: spring(y, { stiffness: 120, damping: 20 }),
-  },
-  {
+  }, {
     scaleX: spring(1, { stiffness: 120, damping: 20 }),
     scaleY: spring(1, { stiffness: 120, damping: 20 }),
     x: spring(x, { stiffness: 120, damping: 20 }),
@@ -115,9 +113,9 @@ export default class MenuItem extends Component {
                 position: 'absolute',
               },
             },
-                    )
-                )
-                }
+          )
+        )
+       }
       </Motion>
     );
   }

--- a/src/item.js
+++ b/src/item.js
@@ -2,123 +2,123 @@ import React, { Component, PropTypes, cloneElement } from 'react';
 import { Motion, spring } from 'react-motion';
 
 const createSmoothParams = ({ x, y }) => ([
-    {
-        scaleX: spring(0, { stiffness: 1500, damping: 100 }),
-        scaleY: spring(0, { stiffness: 1500, damping: 100 }),
-        x: spring(x, { stiffness: 1500, damping: 50 }),
-        y: spring(y, { stiffness: 1500, damping: 50 }),
-    },
-    {
-        scaleX: spring(0.5, { stiffness: 120, damping: 20 }),
-        scaleY: spring(0.5, { stiffness: 120, damping: 20 }),
-        x: spring(x, { stiffness: 120, damping: 20 }),
-        y: spring(y, { stiffness: 120, damping: 20 }),
-    },
-    {
-        scaleX: spring(1, { stiffness: 120, damping: 20 }),
-        scaleY: spring(1, { stiffness: 120, damping: 20 }),
-        x: spring(x, { stiffness: 120, damping: 20 }),
-        y: spring(y, { stiffness: 120, damping: 20 }),
-    },
+  {
+    scaleX: spring(0, { stiffness: 1500, damping: 100 }),
+    scaleY: spring(0, { stiffness: 1500, damping: 100 }),
+    x: spring(x, { stiffness: 1500, damping: 50 }),
+    y: spring(y, { stiffness: 1500, damping: 50 }),
+  },
+  {
+    scaleX: spring(0.5, { stiffness: 120, damping: 20 }),
+    scaleY: spring(0.5, { stiffness: 120, damping: 20 }),
+    x: spring(x, { stiffness: 120, damping: 20 }),
+    y: spring(y, { stiffness: 120, damping: 20 }),
+  },
+  {
+    scaleX: spring(1, { stiffness: 120, damping: 20 }),
+    scaleY: spring(1, { stiffness: 120, damping: 20 }),
+    x: spring(x, { stiffness: 120, damping: 20 }),
+    y: spring(y, { stiffness: 120, damping: 20 }),
+  },
 ]);
 
-const createBumpyParams = ( x, y ) => ([
-        {
-            scaleX: spring(0, { stiffness: 1500, damping: 100 }),
-            scaleY: spring(0, { stiffness: 1500, damping: 100 }),
-            x: spring(x, { stiffness: 1500, damping: 50 }),
-            y: spring(y, { stiffness: 1500, damping: 50 }),
-        },
-        {
-            scaleX: spring(1.6, { stiffness: 1500, damping: 150 }),
-            scaleY: spring(0.7, { stiffness: 1500, damping: 150 }),
-            x: spring(x, { stiffness: 1500, damping: 100 }),
-            y: spring(y, { stiffness: 1500, damping: 100 }),
-        },
-        {
-            scaleX: spring(1, { stiffness: 1500, damping: 18 }),
-            scaleY: spring(1, { stiffness: 1500, damping: 18 }),
-            x: spring(x, { stiffness: 1500, damping: 100 }),
-            y: spring(y, { stiffness: 1500, damping: 100 }),
-        },
+const createBumpyParams = (x, y) => ([
+  {
+    scaleX: spring(0, { stiffness: 1500, damping: 100 }),
+    scaleY: spring(0, { stiffness: 1500, damping: 100 }),
+    x: spring(x, { stiffness: 1500, damping: 50 }),
+    y: spring(y, { stiffness: 1500, damping: 50 }),
+  },
+  {
+    scaleX: spring(1.6, { stiffness: 1500, damping: 150 }),
+    scaleY: spring(0.7, { stiffness: 1500, damping: 150 }),
+    x: spring(x, { stiffness: 1500, damping: 100 }),
+    y: spring(y, { stiffness: 1500, damping: 100 }),
+  },
+  {
+    scaleX: spring(1, { stiffness: 1500, damping: 18 }),
+    scaleY: spring(1, { stiffness: 1500, damping: 18 }),
+    x: spring(x, { stiffness: 1500, damping: 100 }),
+    y: spring(y, { stiffness: 1500, damping: 100 }),
+  },
 ]);
 
 
 export default class MenuItem extends Component {
 
-    static propTypes = {
-        x: PropTypes.number.isRequired,
-        y: PropTypes.number.isRequired,
-        name: PropTypes.string.isRequired,
-        onOpenAnimationEnd: PropTypes.func,
-        onCloseAnimationEnd: PropTypes.func,
-        bumpy: PropTypes.bool.isRequired,
-        speedOpen: PropTypes.number,
-        openSpeed: PropTypes.number,
-        reverse: PropTypes.bool,
-        type: PropTypes.oneOf(['horizontal', 'vertical', 'circle']).isRequired,
-}
+  static propTypes = {
+    x: PropTypes.number.isRequired,
+    y: PropTypes.number.isRequired,
+    name: PropTypes.string.isRequired,
+    onOpenAnimationEnd: PropTypes.func,
+    onCloseAnimationEnd: PropTypes.func,
+    bumpy: PropTypes.bool.isRequired,
+    speedOpen: PropTypes.number,
+    openSpeed: PropTypes.number,
+    reverse: PropTypes.bool,
+    type: PropTypes.oneOf(['horizontal', 'vertical', 'circle']).isRequired,
+  }
 
-    static defaultProps = {
-        onOpenAnimationEnd: () => {},
-        onCloseAnimationEnd: () => {},
-    }
+  static defaultProps = {
+    onOpenAnimationEnd: () => {},
+    onCloseAnimationEnd: () => {},
+  }
 
-    constructor(props) {
-        super(props);
-        this.timerIds = [];
-        this.state = {
-            sequence: 0,
-        };
+  constructor(props) {
+    super(props);
+    this.timerIds = [];
+    this.state = {
+      sequence: 0,
+    };
 
-        this.sequenceParams =  this.props.bumpy ? createBumpyParams(props) : createSmoothParams(props);
-    }
+    this.sequenceParams = this.props.bumpy ? createBumpyParams(props) : createSmoothParams(props);
+  }
 
-    start() {
-        this.timerIds[1] = setTimeout(() => {
-            this.setState({ sequence: 1 });
-            this.timerIds[1] = null;
-        }, this.props.openSpeed);
+  start() {
+    this.timerIds[1] = setTimeout(() => {
+      this.setState({ sequence: 1 });
+      this.timerIds[1] = null;
+    }, this.props.openSpeed);
 
-        this.timerIds[2] = setTimeout(() => {
-            this.setState({ sequence: 2 });
-            this.timerIds[2] = null;
-            this.props.onOpenAnimationEnd(this.props.name);
-        }, this.props.openSpeed);
-    }
+    this.timerIds[2] = setTimeout(() => {
+      this.setState({ sequence: 2 });
+      this.timerIds[2] = null;
+      this.props.onOpenAnimationEnd(this.props.name);
+    }, this.props.openSpeed);
+  }
 
-    reverse() {
-        this.timerIds.forEach((id) => { if (id) clearTimeout(id); });
-        this.timerIds[0] = setTimeout(() => {
-            this.timerIds[0] = null;
-            this.props.onCloseAnimationEnd(this.props.name);
-        }, 80);
-        this.setState({ sequence: 0 });
-    }
+  reverse() {
+    this.timerIds.forEach((id) => { if (id) clearTimeout(id); });
+    this.timerIds[0] = setTimeout(() => {
+      this.timerIds[0] = null;
+      this.props.onCloseAnimationEnd(this.props.name);
+    }, 80);
+    this.setState({ sequence: 0 });
+  }
 
-    render() {
-        const { x, y, reverse, type } = this.props;
-        const _x = reverse ? (-1) * (x) : x;
-        const _y = (type === 'vertical' && reverse) ? (-1) * (y) : y;
-        if (!this.props.children) return null;
-        return (
-            <Motion style={this.sequenceParams[this.state.sequence]}>
-                {({ scaleX, scaleY }) => (
+  render() {
+    const { x, y, reverse, type } = this.props;
+    const _x = reverse ? (-1) * (x) : x;
+    const _y = (type === 'vertical' && reverse) ? (-1) * (y) : y;
+    if (!this.props.children) return null;
+    return (
+      <Motion style={this.sequenceParams[this.state.sequence]}>
+        {({ scaleX, scaleY }) => (
                     cloneElement(
                         this.props.children,
-                        {
-                            ...(this.props.children.props || {}),
-                            style: {
-                                ...((this.props.children.props && this.props.children.props.style) || {}),
-                                transform: `translate3d(${_x}px, ${_y}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`,
-                                WebkitTransform: `translate3d(${_x}px, ${_y}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`,
-                                position: 'absolute',
-                            },
+                      {
+                        ...(this.props.children.props || {}),
+                        style: {
+                          ...((this.props.children.props && this.props.children.props.style) || {}),
+                          transform: `translate3d(${_x}px, ${_y}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`,
+                          WebkitTransform: `translate3d(${_x}px, ${_y}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`,
+                          position: 'absolute',
                         },
+                      },
                     )
                 )
                 }
-            </Motion>
-        );
-    }
+      </Motion>
+    );
+  }
 }

--- a/src/item.js
+++ b/src/item.js
@@ -55,8 +55,9 @@ export default class MenuItem extends Component {
         bumpy: PropTypes.bool.isRequired,
         speedOpen: PropTypes.number,
         openSpeed: PropTypes.number,
-        reverse: PropTypes.bool
-    }
+        reverse: PropTypes.bool,
+        type: PropTypes.oneOf(['horizontal', 'vertical', 'circle']).isRequired,
+}
 
     static defaultProps = {
         onOpenAnimationEnd: () => {},
@@ -96,9 +97,9 @@ export default class MenuItem extends Component {
     }
 
     render() {
-        const { x, y, reverse } = this.props;
+        const { x, y, reverse, type } = this.props;
         const _x = reverse ? (-1) * (x) : x;
-
+        const _y = (type === 'vertical' && reverse) ? (-1) * (y) : y;
         if (!this.props.children) return null;
         return (
             <Motion style={this.sequenceParams[this.state.sequence]}>
@@ -109,8 +110,8 @@ export default class MenuItem extends Component {
                             ...(this.props.children.props || {}),
                             style: {
                                 ...((this.props.children.props && this.props.children.props.style) || {}),
-                                transform: `translate3d(${_x}px, ${y}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`,
-                                WebkitTransform: `translate3d(${_x}px, ${y}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`,
+                                transform: `translate3d(${_x}px, ${_y}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`,
+                                WebkitTransform: `translate3d(${_x}px, ${_y}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`,
                                 position: 'absolute',
                             },
                         },

--- a/src/item.js
+++ b/src/item.js
@@ -22,7 +22,7 @@ const createSmoothParams = ({ x, y }) => ([
     },
 ]);
 
-const createBumpyParams = ({ x, y }) => ([
+const createBumpyParams = ( x, y ) => ([
         {
             scaleX: spring(0, { stiffness: 1500, damping: 100 }),
             scaleY: spring(0, { stiffness: 1500, damping: 100 }),
@@ -54,7 +54,8 @@ export default class MenuItem extends Component {
         onCloseAnimationEnd: PropTypes.func,
         bumpy: PropTypes.bool.isRequired,
         speedOpen: PropTypes.number,
-        openSpeed: PropTypes.number
+        openSpeed: PropTypes.number,
+        rightToLeft: PropTypes.bool
     }
 
     static defaultProps = {
@@ -68,6 +69,7 @@ export default class MenuItem extends Component {
         this.state = {
             sequence: 0,
         };
+
         this.sequenceParams =  this.props.bumpy ? createBumpyParams(props) : createSmoothParams(props);
     }
 
@@ -94,7 +96,14 @@ export default class MenuItem extends Component {
     }
 
     render() {
-        const { x, y } = this.props;
+        const { x, y, rightToLeft } = this.props;
+        let _X;
+        if (rightToLeft){
+            _X = (-1) * (x);
+        }else {
+            _X = x;
+        }
+
         if (!this.props.children) return null;
         return (
             <Motion style={this.sequenceParams[this.state.sequence]}>
@@ -105,8 +114,8 @@ export default class MenuItem extends Component {
                             ...(this.props.children.props || {}),
                             style: {
                                 ...((this.props.children.props && this.props.children.props.style) || {}),
-                                transform: `translate3d(${x}px, ${y}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`,
-                                WebkitTransform: `translate3d(${x}px, ${y}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`,
+                                transform: `translate3d(${_X}px, ${y}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`,
+                                WebkitTransform: `translate3d(${_X}px, ${y}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`,
                                 position: 'absolute',
                             },
                         },

--- a/src/item.js
+++ b/src/item.js
@@ -51,8 +51,8 @@ export default class MenuItem extends Component {
     onOpenAnimationEnd: PropTypes.func,
     onCloseAnimationEnd: PropTypes.func,
     bumpy: PropTypes.bool.isRequired,
-    openSpeed: PropTypes.number,
-    reverse: PropTypes.bool,
+    openSpeed: PropTypes.number.isRequired,
+    reverse: PropTypes.bool.isRequired,
     type: PropTypes.oneOf(['horizontal', 'vertical', 'circle']).isRequired,
   }
 

--- a/src/item.js
+++ b/src/item.js
@@ -104,17 +104,17 @@ export default class MenuItem extends Component {
     return (
       <Motion style={this.sequenceParams[this.state.sequence]}>
         {({ scaleX, scaleY }) => (
-                    cloneElement(
-                        this.props.children,
-                      {
-                        ...(this.props.children.props || {}),
-                        style: {
-                          ...((this.props.children.props && this.props.children.props.style) || {}),
-                          transform: `translate3d(${_x}px, ${_y}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`,
-                          WebkitTransform: `translate3d(${_x}px, ${_y}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`,
-                          position: 'absolute',
-                        },
-                      },
+          cloneElement(
+            this.props.children,
+            {
+              ...(this.props.children.props || {}),
+              style: {
+                ...((this.props.children.props && this.props.children.props.style) || {}),
+                transform: `translate3d(${_x}px, ${_y}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`,
+                WebkitTransform: `translate3d(${_x}px, ${_y}px, 0) scaleX(${scaleX}) scaleY(${scaleY})`,
+                position: 'absolute',
+              },
+            },
                     )
                 )
                 }

--- a/test/test-button.js
+++ b/test/test-button.js
@@ -8,7 +8,7 @@ describe('Button Component test', () => {
 
   it('should mount button component without error', () => {
     mount(
-      <MenuButton x={0} y={0} onClick={() => {}}>
+      <MenuButton x={0} y={0} onClick={() => {}} bumpy={true}>
         <div>sample</div>
       </MenuButton>,
     );

--- a/test/test-button.js
+++ b/test/test-button.js
@@ -5,18 +5,17 @@ import { mount, shallow } from 'enzyme';
 import MenuButton from '../src/button';
 
 describe('Button Component test', () => {
-
   it('should mount button component without error', () => {
     mount(
-      <MenuButton x={0} y={0} onClick={() => {}}>
+      <MenuButton x={0} y={0} onClick={() => {}} bumpy >
         <div>sample</div>
       </MenuButton>,
     );
   });
 
-  it('should x, y position set to button component', () => {
+  it('should x, y position set to button component with bumpy', () => {
     const button = mount(
-      <MenuButton x={10} y={20} onClick={() => {}}>
+      <MenuButton x={10} y={20} onClick={() => {}} bumpy >
         <div>sample</div>
       </MenuButton>,
     );
@@ -24,10 +23,20 @@ describe('Button Component test', () => {
     assert.equal(button.getDOMNode().style.position, 'absolute');
   });
 
+  it('should x, y position set to button component with smooth effect', () => {
+    const button = mount(
+      <MenuButton x={10} y={20} onClick={() => {}} bumpy={false} >
+        <div>sample</div>
+      </MenuButton>,
+        );
+    assert.equal(button.getDOMNode().style.transform, 'translate3d(10px, 20px, 0px) scaleX(1) scaleY(1)');
+    assert.equal(button.getDOMNode().style.position, 'absolute');
+  });
+
   it('should call onClick when button clicked', () => {
     const onClick = spy();
     const button = mount(
-      <MenuButton x={10} y={20} onClick={onClick}>
+      <MenuButton x={10} y={20} onClick={onClick} bumpy>
         <div>sample</div>
       </MenuButton>,
     );

--- a/test/test-button.js
+++ b/test/test-button.js
@@ -8,7 +8,7 @@ describe('Button Component test', () => {
 
   it('should mount button component without error', () => {
     mount(
-      <MenuButton x={0} y={0} onClick={() => {}} bumpy={true}>
+      <MenuButton x={0} y={0} onClick={() => {}}>
         <div>sample</div>
       </MenuButton>,
     );

--- a/test/test-item.js
+++ b/test/test-item.js
@@ -10,7 +10,7 @@ describe('Item Component test', function () {
 
   it('should mount item component without error', () => {
     mount(
-      <MenuItem x={0} y={0} name="sample">
+      <MenuItem x={0} y={0} name="sample" bumpy openSpeed={60} type={'circle'} reverse={false}>
         <div>sample</div>
       </MenuItem>,
     );
@@ -19,7 +19,7 @@ describe('Item Component test', function () {
   it('should call onOpenAnimationEnd callback, when opend', (done) => {
     const onOpenAnimationEnd = spy();
     const wrapper = shallow(
-      <MenuItem x={0} y={0} name="sample" onOpenAnimationEnd={onOpenAnimationEnd}>
+      <MenuItem x={0} y={0} name="sample" onOpenAnimationEnd={onOpenAnimationEnd} bumpy openSpeed={60} type={'circle'} reverse={false}>
         <div>sample</div>
       </MenuItem>,
     );
@@ -33,7 +33,7 @@ describe('Item Component test', function () {
 
   it('should call onOpenAnimationEnd callback, when opend', (done) => {
     const wrapper = mount(
-      <MenuItem x={10} y={20} name="sample">
+      <MenuItem x={10} y={20} name="sample" bumpy openSpeed={60} type={'circle'} reverse={false}>
         <div>sample</div>
       </MenuItem>,
     );
@@ -47,7 +47,7 @@ describe('Item Component test', function () {
   it('should call onCloseAnimationEnd callback, when closed', (done) => {
     const onCloseAnimationEnd = spy();
     const wrapper = shallow(
-      <MenuItem x={0} y={0} name="sample" onCloseAnimationEnd={onCloseAnimationEnd}>
+      <MenuItem x={0} y={0} name="sample" onCloseAnimationEnd={onCloseAnimationEnd} bumpy openSpeed={60} type={'circle'} reverse={false}>
         <div>sample</div>
       </MenuItem>,
     );


### PR DESCRIPTION
We liked the React-motion-menu, because it is very easy to use and understandable. 
To give user more control over the menu, we have introduced some extra props for the MotionMenu component. 

**New Props** 
1. bumpy: (bool): This prop controls if the menu Items should bump or open smoothly.
2. openSpeed: (number): (miliseconds) This controls the speed of the menu while opening. 
3. reverse: (bool) : This controls if the menu should open in reverse order. 
